### PR TITLE
Add new directive DataRef for users to add in data dependencies.

### DIFF
--- a/crates/driver/src/print_build.rs
+++ b/crates/driver/src/print_build.rs
@@ -330,6 +330,10 @@ async fn print_file(
                                 let t = extra_kv_pairs.entry("deps".to_string()).or_default();
                                 t.push(manual_ref.target_value.clone())
                             }
+                            directive::ManualRefDirective::DataRef => {
+                                let t = extra_kv_pairs.entry("data".to_string()).or_default();
+                                t.push(manual_ref.target_value.clone())
+                            }
                         },
                     }
                 }
@@ -431,6 +435,12 @@ async fn print_file(
                 directive::ManualRefDirective::Ref => {
                     extra_kv_pairs
                         .entry("deps".to_string())
+                        .or_default()
+                        .push(manual_ref.target_value.clone());
+                }
+                directive::ManualRefDirective::DataRef => {
+                    extra_kv_pairs
+                        .entry("data".to_string())
                         .or_default()
                         .push(manual_ref.target_value.clone());
                 }

--- a/crates/shared_types/src/directive.rs
+++ b/crates/shared_types/src/directive.rs
@@ -51,6 +51,7 @@ impl std::fmt::Display for SrcDirective {
 pub enum ManualRefDirective {
     RuntimeRef,
     Ref,
+    DataRef,
 }
 impl ManualRefDirective {
     pub fn parse<'a, E: ParseError<&'a str> + ContextError<&'a str>>(
@@ -59,6 +60,7 @@ impl ManualRefDirective {
         alt((
             value(ManualRefDirective::RuntimeRef, tag("manual_runtime_ref")),
             value(ManualRefDirective::Ref, tag("manual_ref")),
+            value(ManualRefDirective::DataRef, tag("data_ref")),
         ))(input)
     }
 }
@@ -66,7 +68,8 @@ impl std::fmt::Display for ManualRefDirective {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             ManualRefDirective::RuntimeRef => write!(f, "manual_runtime_ref"),
-            ManualRefDirective::Ref => write!(f, "manual_runtime_ref"),
+            ManualRefDirective::Ref => write!(f, "manual_ref"),
+            ManualRefDirective::DataRef => write!(f, "data_ref"),
         }
     }
 }
@@ -450,6 +453,14 @@ mod tests {
             Directive::ManualRef(ManualRefConfig {
                 command: ManualRefDirective::RuntimeRef,
                 target_value: "//:build_gradle_properties_jar".to_string()
+            })
+        );
+
+        assert_eq!(
+            parse_to_directive("data_ref://x/y/z:artifact"),
+            Directive::ManualRef(ManualRefConfig {
+                command: ManualRefDirective::DataRef,
+                target_value: "//x/y/z:artifact".to_string()
             })
         );
 


### PR DESCRIPTION
Added a new directive DataRef in the manual ref family. This allows users to specify data dependencies for build targets. 

The main benefit of having DataRef is it helps bridge the cross language data pass. For example if users have some information built in one language, they are now able to pass through that information through genrules (or other custom rule) to targets in other languages. 

Some other benefits include
1. A natural way for specifying what data to read for python rules.
2. Allow Java/Scala tests to read data from a filepath instead of resources. 