### PR TITLE
Implement attr.string_list

### DIFF
--- a/crates/driver/src/print_build.rs
+++ b/crates/driver/src/print_build.rs
@@ -450,7 +450,6 @@ async fn print_file(
 
     apply_manual_refs(&mut extra_kv_pairs, &graph_node.node_metadata);
 
-
     fn append_key_values(
         extra_kv_pairs: &mut HashMap<String, Vec<String>>,
         key: &String,
@@ -461,7 +460,6 @@ async fn print_file(
             .or_default()
             .extend(values.iter().cloned());
     }
-
 
     fn apply_attr_string_lists(
         extra_kv_pairs: &mut HashMap<String, Vec<String>>,

--- a/crates/driver/src/print_build.rs
+++ b/crates/driver/src/print_build.rs
@@ -300,10 +300,7 @@ async fn print_file(
     };
 
     for (k, lst) in build_config.extra_key_to_list.iter() {
-        extra_kv_pairs
-            .entry(k.clone())
-            .or_default()
-            .extend(lst.iter().cloned())
+        append_key_values(&mut extra_kv_pairs, &k, &lst);
     }
 
     for directive in project_conf
@@ -336,10 +333,7 @@ async fn print_file(
                             }
                         },
                         Directive::AttrStringList(attr) => {
-                            let t = extra_kv_pairs
-                                .entry(attr.attr_name.to_string())
-                                .or_default();
-                            t.push(attr.value.clone())
+                            append_key_values(&mut extra_kv_pairs, &attr.attr_name, &attr.values);
                         }
                     }
                 }
@@ -456,15 +450,25 @@ async fn print_file(
 
     apply_manual_refs(&mut extra_kv_pairs, &graph_node.node_metadata);
 
+
+    fn append_key_values(
+        extra_kv_pairs: &mut HashMap<String, Vec<String>>,
+        key: &String,
+        values: &Vec<String>,
+    ) {
+        extra_kv_pairs
+            .entry(key.clone())
+            .or_default()
+            .extend(values.iter().cloned());
+    }
+
+
     fn apply_attr_string_lists(
         extra_kv_pairs: &mut HashMap<String, Vec<String>>,
         node_metadata: &GraphNodeMetadata,
     ) {
         for attr in node_metadata.attr_string_lists.iter() {
-            let t = extra_kv_pairs
-                .entry(attr.attr_name.to_string())
-                .or_default();
-            t.push(attr.value.clone());
+            append_key_values(extra_kv_pairs, &attr.attr_name, &attr.values);
         }
     }
 

--- a/crates/driver/src/print_build.rs
+++ b/crates/driver/src/print_build.rs
@@ -335,6 +335,12 @@ async fn print_file(
                                 t.push(manual_ref.target_value.clone())
                             }
                         },
+                        Directive::AttrStringList(attr) => {
+                            let t = extra_kv_pairs
+                                .entry(attr.attr_name.to_string())
+                                .or_default();
+                            t.push(attr.value.clone())
+                        }
                     }
                 }
             }
@@ -450,6 +456,20 @@ async fn print_file(
 
     apply_manual_refs(&mut extra_kv_pairs, &graph_node.node_metadata);
 
+    fn apply_attr_string_lists(
+        extra_kv_pairs: &mut HashMap<String, Vec<String>>,
+        node_metadata: &GraphNodeMetadata,
+    ) {
+        for attr in node_metadata.attr_string_lists.iter() {
+            let t = extra_kv_pairs
+                .entry(attr.attr_name.to_string())
+                .or_default();
+            t.push(attr.value.clone());
+        }
+    }
+
+    apply_attr_string_lists(&mut extra_kv_pairs, &graph_node.node_metadata);
+
     if use_rglob {
         let target = TargetEntry {
             name: target_name.clone(),
@@ -512,6 +532,7 @@ async fn print_file(
                 };
 
                 apply_manual_refs(&mut extra_kv_pairs, metadata);
+                apply_attr_string_lists(&mut extra_kv_pairs, metadata);
 
                 let mut t = TargetEntries {
                     entries: vec![filegroup_target],

--- a/crates/shared_types/src/directive.rs
+++ b/crates/shared_types/src/directive.rs
@@ -357,10 +357,7 @@ impl Directive {
 
         let (input, _) = nom::combinator::eof(input)?;
 
-        Ok((
-            input,
-            (src_entity, dest_entities),
-        ))
+        Ok((input, (src_entity, dest_entities)))
     }
 
     pub fn parse_entity_directive<'a, E: ParseError<&'a str> + ContextError<&'a str>>(
@@ -413,9 +410,12 @@ impl Directive {
 
 impl std::fmt::Display for Directive {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-
-        fn write_string_list(f: &mut std::fmt::Formatter<'_>,
-                command: &String, name: &String, values: &Vec<String>) -> std::fmt::Result {
+        fn write_string_list(
+            f: &mut std::fmt::Formatter<'_>,
+            command: &String,
+            name: &String,
+            values: &Vec<String>,
+        ) -> std::fmt::Result {
             write!(f, "{}:", command)?;
             write!(f, "{}", name)?;
             write!(f, " -> {{")?;
@@ -430,7 +430,6 @@ impl std::fmt::Display for Directive {
             write!(f, " }}")?;
             Ok(())
         }
-
 
         match self {
             Directive::ManualRef(ManualRefConfig {

--- a/crates/shared_types/src/internal_types/tree_node.rs
+++ b/crates/shared_types/src/internal_types/tree_node.rs
@@ -3,7 +3,10 @@ use std::collections::HashSet;
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    directive::{BinaryRefAndPath, EntityDirectiveConfig, ManualRefConfig, SrcDirectiveConfig},
+    directive::{
+        AttrStringListConfig, BinaryRefAndPath, EntityDirectiveConfig, ManualRefConfig,
+        SrcDirectiveConfig,
+    },
     Directive,
 };
 
@@ -28,6 +31,9 @@ pub struct TreeNode {
 
     #[serde(default, serialize_with = "crate::serde_helpers::ordered_list")]
     pub binary_ref_directives: Vec<BinaryRefAndPath>,
+
+    #[serde(default, serialize_with = "crate::serde_helpers::ordered_list")]
+    pub attr_string_list_directives: Vec<AttrStringListConfig>,
 }
 
 impl TryFrom<crate::api::extracted_data::DataBlock> for TreeNode {
@@ -78,6 +84,9 @@ impl TreeNode {
                     entity_path: entity_path.map(|e| e.to_string()),
                     binary_refs: mr.clone(),
                 }),
+                Directive::AttrStringList(attr) => {
+                    self.attr_string_list_directives.push(attr.clone())
+                }
             }
         }
         self.entity_directives.sort();
@@ -88,6 +97,9 @@ impl TreeNode {
 
         self.manual_ref_directives.sort();
         self.manual_ref_directives.dedup();
+
+        self.attr_string_list_directives.sort();
+        self.attr_string_list_directives.dedup();
     }
 
     pub fn apply_directives<'a, T>(&mut self, directives: T)
@@ -121,5 +133,10 @@ impl TreeNode {
             .extend(std::mem::take(&mut other.manual_ref_directives).into_iter());
         self.manual_ref_directives.sort();
         self.manual_ref_directives.dedup();
+
+        self.attr_string_list_directives
+            .extend(std::mem::take(&mut other.attr_string_list_directives).into_iter());
+        self.attr_string_list_directives.sort();
+        self.attr_string_list_directives.dedup();
     }
 }


### PR DESCRIPTION
## Problem
There are some situations where we'd want to access the underlying rules, like `scala_library`. We probably don't want to keep adding one-off, language-specific directives.

## Solution
This is somewhat generic solution that passes both the field name and the value.

## Notes
```scala
// bzl_gen_build:attr.string_list: plugins -> { foo }
object SomeMain extends IOApp {
```

This generates

```diff
+    plugins = ["foo"],
```