### PR TITLE
Remove Ubuntu 18.04, add Ubuntu 22.04

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,17 +9,17 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        os: [macos-latest, ubuntu-20.04, ubuntu-18.04]
+        os: [macos-latest, ubuntu-22.04, ubuntu-20.04]
         include:
           - os: macos-latest
             platform: macos-x86
             artifact: bzl-gen-build-macos-x86
+          - os: ubuntu-22.04
+            platform: linux-ubuntu-22.04
+            artifact: bzl-gen-build-linux-ubuntu-22.04
           - os: ubuntu-20.04
             platform: linux-ubuntu-20.04
             artifact: bzl-gen-build-linux-ubuntu-20.04
-          - os: ubuntu-18.04
-            platform: linux-ubuntu-18.04
-            artifact: bzl-gen-build-linux-ubuntu-18.04
     steps:
       - uses: actions/checkout@v2
       - name: Install Protoc
@@ -46,15 +46,15 @@ jobs:
         uses: arduino/setup-protoc@v1
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Download linux bzl-gen-build 22
+        uses: actions/download-artifact@v1
+        with:
+          name: bzl-gen-build-linux-ubuntu-22.04
+          path: downloads
       - name: Download linux ubuntu 20 bzl-gen-build
         uses: actions/download-artifact@v1
         with:
           name: bzl-gen-build-linux-ubuntu-20.04
-          path: downloads
-      - name: Download linux bzl-gen-build 18
-        uses: actions/download-artifact@v1
-        with:
-          name: bzl-gen-build-linux-ubuntu-18.04
           path: downloads
       - name: Download macos bzl-gen-build
         uses: actions/download-artifact@v1
@@ -70,8 +70,8 @@ jobs:
           files: |
             downloads/bzl-gen-build-macos-x86.tgz
             downloads/bzl-gen-build-macos-x86.tgz.sha256
+            downloads/bzl-gen-build-linux-ubuntu-22.04.tgz
+            downloads/bzl-gen-build-linux-ubuntu-22.04.tgz.sha256
             downloads/bzl-gen-build-linux-ubuntu-20.04.tgz
             downloads/bzl-gen-build-linux-ubuntu-20.04.tgz.sha256
-            downloads/bzl-gen-build-linux-ubuntu-18.04.tgz
-            downloads/bzl-gen-build-linux-ubuntu-18.04.tgz.sha256
         id: "automatic_releases"


### PR DESCRIPTION
Fixes https://github.com/bazeltools/bzl-gen-build/issues/37

**Problem**
Ubuntu 18.04 CI runner image is no longer available.

**Solution**
This adds Ubuntu 22.04 image instead, in addition to currently available Ubuntu 20.04.