### PR TITLE
Fix typo in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Modulular build generator
+# Modular build generator
 
 This is a modular build generator, its designed so its easy to pick and choose components, modify intermediate states (all json). post process or use the outputs for new purposes as it makes sense.
 


### PR DESCRIPTION
Was cloning the repo and noticed the typo in the heading. 