### PR TITLE
Implement directives support for Protobuf

### DIFF
--- a/crates/protobuf_extractor/src/main.rs
+++ b/crates/protobuf_extractor/src/main.rs
@@ -1,8 +1,8 @@
-use std::{collections::HashSet, path::PathBuf, time::Instant};
 use anyhow::{Context, Result};
 use bzl_gen_build_shared_types::api::extracted_data::{DataBlock, ExtractedData};
 use clap::Parser;
 use log::debug;
+use std::{collections::HashSet, path::PathBuf, time::Instant};
 
 mod extract_protobuf_imports;
 use extract_protobuf_imports::ProtobufSource;
@@ -65,7 +65,7 @@ async fn main() -> Result<()> {
         let input_file = opt.working_directory.join(&relative_path);
         let mut refs: HashSet<String> = Default::default();
         let mut defs: HashSet<String> = Default::default();
-        let bzl_gen_build_commands: HashSet<String> = Default::default();
+        let mut bzl_gen_build_commands: HashSet<String> = Default::default();
 
         let input_str = std::fs::read_to_string(&input_file).with_context(|| {
             format!(
@@ -75,15 +75,18 @@ async fn main() -> Result<()> {
             )
         })?;
 
-        if !opt.disable_ref_generation {
-            let program = ProtobufSource::parse(&input_str, &relative_path).with_context(|| {
-                format!(
-                    "Error while parsing file {:?
-        }",
-                    input_file
-                )
-            })?;
+        let program = ProtobufSource::parse(&input_str, &relative_path).with_context(|| {
+            format!(
+                "Error while parsing file {:?
+    }",
+                input_file
+            )
+        })?;
 
+        if !program.bzl_gen_build_commands.is_empty() {
+            bzl_gen_build_commands.extend(program.bzl_gen_build_commands);
+        }
+        if !opt.disable_ref_generation {
             refs.extend(program.imports);
         }
 

--- a/crates/python_extractor/src/extract_py_bzl_gen_build_commands.rs
+++ b/crates/python_extractor/src/extract_py_bzl_gen_build_commands.rs
@@ -1,12 +1,10 @@
+use bzl_gen_build_shared_types::Directive;
+
 pub fn extract(python_src: &str) -> Vec<String> {
     let mut buf = Vec::default();
     for ln in python_src.lines() {
-        if let Some(comment_line) = ln.trim_start().strip_prefix('#') {
-            if let Some(matching) = comment_line.trim_start().strip_prefix("bzl_gen_build") {
-                if let Some(bzl_command) = matching.trim_start().strip_prefix(':') {
-                    buf.push(bzl_command.trim().to_string());
-                }
-            }
+        if let Some(bzl_command) = Directive::extract_directive(&ln, "#") {
+            buf.push(bzl_command.trim().to_string());
         }
     }
     buf.sort();

--- a/crates/python_extractor/src/main.rs
+++ b/crates/python_extractor/src/main.rs
@@ -125,8 +125,10 @@ async fn main() -> Result<()> {
 fn expand_path_to_defs_from_offset(from_given_path: &str, path: &str) -> Vec<String> {
     // rules_python Bzlmod support uses pip-tools, which I think places the 3rdparty
     // source files inside a site-packages/ directory, per module.
-    if let Some(rem) = path.strip_prefix(from_given_path)
-        .and_then(|p| Some(p.strip_prefix("site-packages/").unwrap_or(p))) {
+    if let Some(rem) = path
+        .strip_prefix(from_given_path)
+        .and_then(|p| Some(p.strip_prefix("site-packages/").unwrap_or(p)))
+    {
         if let Some(e) = rem.strip_suffix(".py") {
             let targ = e.replace('/', ".");
 

--- a/crates/shared_types/src/directive.rs
+++ b/crates/shared_types/src/directive.rs
@@ -406,6 +406,15 @@ impl Directive {
             Directive::parse_attr_string_list_directive,
         ))(input)
     }
+
+    pub fn extract_directive(raw_comment: &str, comment_prefix: &str) -> Option<String> {
+        raw_comment
+            .trim_start()
+            .strip_prefix(comment_prefix)
+            .and_then(|comment_line| comment_line.trim_start().strip_prefix("bzl_gen_build"))
+            .and_then(|matching| matching.trim_start().strip_prefix(':'))
+            .map(|str| str.to_string())
+    }
 }
 
 impl std::fmt::Display for Directive {

--- a/prepare_all_apps.sh
+++ b/prepare_all_apps.sh
@@ -38,7 +38,7 @@ cp ${RUST_TARGET_DIR}/bzl_gen_build_driver $PREPARE_ALL_OUTPUT_DIR/system-driver
 rm -f  $PREPARE_ALL_OUTPUT_DIR/python-entity-extractor || true
 cp ${RUST_TARGET_DIR}/bzl_gen_python_extractor $PREPARE_ALL_OUTPUT_DIR/python-entity-extractor
 
-rm -f  $PREPARE_ALL_OUTPUT_DIR/protobuf-extractor || true
+rm -f  $PREPARE_ALL_OUTPUT_DIR/protos-entity-extractor || true
 cp ${RUST_TARGET_DIR}/bzl_gen_protobuf_extractor $PREPARE_ALL_OUTPUT_DIR/protos-entity-extractor
 
 rm -f  $PREPARE_ALL_OUTPUT_DIR/jarscanner || true


### PR DESCRIPTION
This is an offshoot of https://github.com/bazeltools/bzl-gen-build/pull/117

Problem/Solution
----------------
Currently Protobuf extractor doesn't support directives.
This adds it via comment similar to other languages.