### PR TITLE
Rename directory to entry as a prep step + Fix deps expansion

### DIFF
--- a/crates/driver/src/main.rs
+++ b/crates/driver/src/main.rs
@@ -181,6 +181,14 @@ fn read_all_project_conf(input_path: &Path, working_directory: &Path) -> Result<
     Ok(v)
 }
 
+pub fn to_directory(rel_path: String) -> String {
+    if let Some(idx) = rel_path.rfind('/') {
+        rel_path.split_at(idx).0.to_string()
+    } else {
+        rel_path
+    }
+}
+
 #[tokio::main]
 async fn main() -> Result<()> {
     let opt = Opt::parse();

--- a/crates/driver/src/print_build.rs
+++ b/crates/driver/src/print_build.rs
@@ -138,7 +138,7 @@ impl SrcType {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Default)]
 struct TargetEntries {
     pub entries: Vec<TargetEntry>,
 }


### PR DESCRIPTION
Here's a small offshoot from https://github.com/bazeltools/bzl-gen-build/pull/117 to make the PR a bit smaller.

Currently the term `directory` shows up a lot in the code base, but this renames it to a more neutral `entry` since the graph can be constructed either at the source-file granularity or at (aggregated) directory granularity.
