### PR TITLE
Well-known protobuf sources

### DIFF
--- a/crates/protobuf_extractor/src/extract_protobuf_imports.rs
+++ b/crates/protobuf_extractor/src/extract_protobuf_imports.rs
@@ -5,6 +5,7 @@ use tree_sitter::Parser;
 #[derive(Debug, PartialEq)]
 pub struct ProtobufSource {
     pub imports: Vec<String>,
+    pub well_known_refs: Vec<String>,
     pub bzl_gen_build_commands: Vec<String>,
 }
 
@@ -12,6 +13,7 @@ impl ProtobufSource {
     pub fn parse(source: &str, _source_path: &str) -> Result<ProtobufSource> {
         let mut buf = Vec::default();
         let mut parser = Parser::new();
+        let mut well_known_refs = Vec::default();
         let mut bzl_gen_build_commands = Vec::default();
         parser.set_language(tree_sitter_proto::language())?;
         let tree = match parser.parse(source, None) {
@@ -29,8 +31,9 @@ impl ProtobufSource {
                         // Remove the quotation marks
                         quoted.next();
                         quoted.next_back();
-                        if !(quoted.as_str().starts_with("google/")) {
-                            buf.push(quoted.as_str().to_string());
+                        match Self::well_known_target(&quoted.as_str()) {
+                            Some(well_known) => well_known_refs.push(well_known.to_string()),
+                            None => buf.push(quoted.as_str().to_string()),
                         }
                     }
                 }
@@ -45,8 +48,23 @@ impl ProtobufSource {
         }
         Ok(ProtobufSource {
             imports: buf,
+            well_known_refs: well_known_refs,
             bzl_gen_build_commands: bzl_gen_build_commands,
         })
+    }
+
+    pub fn well_known_target(path: &str) -> Option<String> {
+        let parts: Vec<&str> = path.split('/').collect();
+        if parts.len() != 3 {
+            None
+        } else if parts[0] != "google" || parts[1] != "protobuf" {
+            None
+        } else {
+            Some(format!(
+                "@com_github_protocolbuffers_protobuf//:{}",
+                parts[2].replace(".", "_")
+            ))
+        }
     }
 }
 
@@ -60,14 +78,14 @@ mod tests {
 
 package page.common; // Requried to generate valid code.
 
-// bzl_gen_build:manual_ref:@com_google_protobuf//:timestamp_proto
-import "google/protobuf/timestamp.proto";
+// bzl_gen_build:manual_ref:aaa
+import "some/aaa.proto";
 
 message Address {
   string city = 1;
 }"#;
         let parsed = ProtobufSource::parse(protobuf_source, "tmp.proto")?;
-        let expected = vec!["manual_ref:@com_google_protobuf//:timestamp_proto"];
+        let expected = vec!["manual_ref:aaa"];
         assert_eq!(parsed.bzl_gen_build_commands, expected);
         Ok(())
     }
@@ -88,6 +106,33 @@ message Address {
         let parsed = ProtobufSource::parse(protobuf_source, "tmp.proto")?;
         let expected = vec!["page/common/src/proto/zip_code.proto".to_string()];
         assert_eq!(parsed.imports, expected);
+        Ok(())
+    }
+
+    #[test]
+    fn test_well_known_target() -> Result<()> {
+        let wk = ProtobufSource::well_known_target("google/protobuf/any.proto");
+        let expected = Some("@com_github_protocolbuffers_protobuf//:any_proto".to_string());
+        assert_eq!(wk, expected);
+        Ok(())
+    }
+
+    #[test]
+    fn test_parse_well_known() -> Result<()> {
+        let protobuf_source = r#"syntax = "proto3";
+
+package page.common; // Requried to generate valid code.
+
+import "google/protobuf/timestamp.proto";
+
+message Address {
+  string city = 1;
+}"#;
+        let parsed = ProtobufSource::parse(protobuf_source, "tmp.proto")?;
+        assert_eq!(parsed.imports, [] as [&str; 0]);
+
+        let expected = vec!["@com_github_protocolbuffers_protobuf//:timestamp_proto".to_string()];
+        assert_eq!(parsed.well_known_refs, expected);
         Ok(())
     }
 }

--- a/crates/protobuf_extractor/src/extract_protobuf_imports.rs
+++ b/crates/protobuf_extractor/src/extract_protobuf_imports.rs
@@ -32,7 +32,7 @@ impl ProtobufSource {
                         quoted.next();
                         quoted.next_back();
                         match Self::well_known_target(&quoted.as_str()) {
-                            Some(well_known) => well_known_refs.push(well_known.to_string()),
+                            Some(well_known) => well_known_refs.push(well_known),
                             None => buf.push(quoted.as_str().to_string()),
                         }
                     }

--- a/crates/protobuf_extractor/src/main.rs
+++ b/crates/protobuf_extractor/src/main.rs
@@ -89,6 +89,14 @@ async fn main() -> Result<()> {
         if !opt.disable_ref_generation {
             refs.extend(program.imports);
         }
+        if !program.well_known_refs.is_empty() {
+            bzl_gen_build_commands.extend(
+                program
+                    .well_known_refs
+                    .into_iter()
+                    .map(|x| format!("manual_ref:{}", x)),
+            )
+        }
 
         // See https://protobuf.dev/programming-guides/proto3/#importing
         // Protobuf uses file path relative to the workspace as a way of importing:


### PR DESCRIPTION
Fixes https://github.com/bazeltools/bzl-gen-build/issues/131

Problem
-------
Currently well-known protobuf sources are not handled automatically, and requires tedious directive commenting.

Solution
--------
This automatically creates `manual_ref` for well-known protobuf sources.