### PR TITLE
Make reader tolerant to files without utf-8 encoding, add some tests

### DIFF
--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -350,6 +350,7 @@ dependencies = [
  "lazy_static",
  "log",
  "pretty_env_logger",
+ "regex",
  "rustpython-ast",
  "rustpython-parser",
  "serde",
@@ -1004,9 +1005,9 @@ checksum = "2532096657941c2fea9c289d370a250971c689d4f143798ff67113ec042024a5"
 
 [[package]]
 name = "memchr"
-version = "2.5.0"
+version = "2.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
+checksum = "8f232d6ef707e1956a43342693d2a31e72989554d58299d7a88738cc95b0d35c"
 
 [[package]]
 name = "minimal-lexical"
@@ -1351,13 +1352,13 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.9.4"
+version = "1.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12de2eff854e5fa4b1295edd650e227e9d8fb0c9e90b12e7f36d6a6811791a29"
+checksum = "697061221ea1b4a94a624f67d0ae2bfe4e22b8a17b6a192afb11046542cc8c47"
 dependencies = [
  "aho-corasick 1.0.5",
  "memchr",
- "regex-automata 0.3.7",
+ "regex-automata 0.3.8",
  "regex-syntax 0.7.5",
 ]
 
@@ -1369,9 +1370,9 @@ checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
 
 [[package]]
 name = "regex-automata"
-version = "0.3.7"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49530408a136e16e5b486e883fbb6ba058e8e4e8ae6621a77b048b314336e629"
+checksum = "c2f401f4955220693b56f8ec66ee9c78abffd8d1c4f23dc41a23839eb88f0795"
 dependencies = [
  "aho-corasick 1.0.5",
  "memchr",

--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -344,6 +344,7 @@ dependencies = [
  "bzl_gen_build_python_utilities",
  "bzl_gen_build_shared_types",
  "clap",
+ "encoding_rs",
  "futures",
  "ignore",
  "lazy_static",
@@ -531,6 +532,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2e5d13ca2353ab7d0230988629def93914a8c4015f621f9b13ed2955614731d"
 dependencies = [
  "log",
+]
+
+[[package]]
+name = "encoding_rs"
+version = "0.8.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7268b386296a025e474d5140678f75d6de9493ae55a5d709eeb9dd08149945e1"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]

--- a/crates/python_extractor/Cargo.toml
+++ b/crates/python_extractor/Cargo.toml
@@ -21,6 +21,7 @@ rustpython-ast = { git = "https://github.com/RustPython/RustPython.git", rev = "
 pretty_env_logger = "0.5.0"
 log = "0.4.20"
 encoding_rs = "0.8.33"
+regex = "1.9.5"
 
 [dev-dependencies]
 tempfile = "3.8.0"

--- a/crates/python_extractor/Cargo.toml
+++ b/crates/python_extractor/Cargo.toml
@@ -20,6 +20,7 @@ rustpython-parser = { git = "https://github.com/RustPython/RustPython.git", rev 
 rustpython-ast = { git = "https://github.com/RustPython/RustPython.git", rev = "b9ed63ed326e4ab9c97d808271ddc1d7ca05fda7", features = ["unparse"]}
 pretty_env_logger = "0.5.0"
 log = "0.4.20"
+encoding_rs = "0.8.33"
 
 [dev-dependencies]
 tempfile = "3.8.0"

--- a/crates/python_extractor/src/lib.rs
+++ b/crates/python_extractor/src/lib.rs
@@ -1,0 +1,183 @@
+use std::{
+    collections::{BTreeSet, HashSet},
+    io::Read,
+    path::PathBuf,
+};
+
+use bzl_gen_build_python_utilities::PythonProgram;
+
+use bzl_gen_build_shared_types::api::extracted_data::{DataBlock, ExtractedData};
+
+use anyhow::{Context, Result};
+
+mod extract_py_bzl_gen_build_commands;
+mod extract_py_imports;
+
+pub async fn extract_python(
+    relative_input_paths: String,
+    working_directory: PathBuf,
+    output: PathBuf,
+    label_or_repo_path: String,
+    disable_ref_generation: bool,
+    import_path_relative_from: Option<String>,
+) -> Result<()> {
+    let mut relative_input_paths: Vec<String> =
+        if let Some(suffix) = relative_input_paths.strip_prefix('@') {
+            std::fs::read_to_string(PathBuf::from(suffix))?
+                .lines()
+                .map(|e| e.to_string())
+                .collect()
+        } else {
+            vec![relative_input_paths.clone()]
+        };
+
+    relative_input_paths.sort();
+
+    let mut data_blocks: Vec<DataBlock> = Default::default();
+
+    for relative_path in relative_input_paths {
+        let input_file = working_directory.join(&relative_path);
+        let mut refs: HashSet<String> = Default::default();
+        let mut defs: BTreeSet<String> = Default::default();
+        let mut bzl_gen_build_commands: HashSet<String> = Default::default();
+
+        let mut file = std::fs::File::open(&input_file).with_context(|| {
+            format!(
+                "While attempting to open file: {:?
+    }",
+                input_file
+            )
+        })?;
+        let mut buffer = Vec::new();
+        file.read_to_end(&mut buffer).with_context(|| {
+            format!(
+                "While attempting to read file: {:?
+    }",
+                input_file
+            )
+        })?;
+
+        let input_str = String::from_utf8_lossy(&buffer).into_owned();
+
+        bzl_gen_build_commands.extend(extract_py_bzl_gen_build_commands::extract(
+            input_str.as_str(),
+        ));
+
+        if !disable_ref_generation {
+            let program = PythonProgram::parse(&input_str, "foo.py").with_context(|| {
+                format!(
+                    "Error while parsing file {:?
+        }",
+                    input_file
+                )
+            })?;
+            refs.extend(extract_py_imports::extract(&program));
+        }
+
+        let file_p = input_file.to_string_lossy();
+
+        if let Some(rel) = import_path_relative_from.as_ref() {
+            defs.extend(expand_path_to_defs_from_offset(rel, file_p.as_ref()));
+        } else {
+            defs.extend(expand_path_to_defs(file_p.as_ref()));
+        }
+        data_blocks.push(DataBlock {
+            entity_path: relative_path,
+            defs,
+            refs,
+            bzl_gen_build_commands,
+        })
+    }
+
+    let def_refs = ExtractedData {
+        label_or_repo_path: label_or_repo_path.clone(),
+        data_blocks,
+    };
+
+    tokio::fs::write(output, serde_json::to_string_pretty(&def_refs)?).await?;
+    Ok(())
+}
+
+fn expand_path_to_defs_from_offset(from_given_path: &str, path: &str) -> Vec<String> {
+    // rules_python Bzlmod support uses pip-tools, which I think places the 3rdparty
+    // source files inside a site-packages/ directory, per module.
+    if let Some(rem) = path
+        .strip_prefix(from_given_path)
+        .and_then(|p| Some(p.strip_prefix("site-packages/").unwrap_or(p)))
+    {
+        if let Some(e) = rem.strip_suffix(".py") {
+            let targ = e.replace('/', ".");
+
+            if let Some(p) = targ.strip_suffix(".__init__") {
+                return vec![p.to_string(), targ.clone()];
+            } else {
+                return vec![targ];
+            }
+        }
+    }
+    Vec::default()
+}
+
+fn expand_path_to_defs(path: &str) -> Vec<String> {
+    let mut results = Vec::default();
+    for element in path.split('/') {
+        results = results
+            .into_iter()
+            .map(|r| format!("{}.{}", r, element))
+            .collect();
+
+        if element == "src" {
+            results.push("src".to_string());
+        }
+    }
+
+    let mut results: Vec<String> = results
+        .into_iter()
+        .map(|e| e.strip_suffix(".py").map(|e| e.to_string()).unwrap_or(e))
+        .collect();
+
+    results.sort();
+    results.dedup();
+    results
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn expand_path_to_defs_test() {
+        let mut expected = vec!["src.main.python.blah.ppp"];
+        expected.sort();
+        expected.dedup();
+
+        assert_eq!(
+            expand_path_to_defs("/Users/foo/bar/src/main/python/blah/ppp.py"),
+            expected
+        );
+    }
+
+    #[test]
+    fn expand_path_to_defs_ambigious_path_test() {
+        let mut expected = vec!["src.main.python.blah.src.main.ppp", "src.main.ppp"];
+        expected.sort();
+        expected.dedup();
+
+        assert_eq!(
+            expand_path_to_defs("/Users/foo/bar/src/main/python/blah/src/main/ppp.py"),
+            expected
+        );
+    }
+
+    #[test]
+    fn expand_site_packages_path_to_defs_test() {
+        let mut expected = vec!["pytz", "pytz.__init__"];
+        expected.sort();
+        expected.dedup();
+
+        assert_eq!(
+            expand_path_to_defs_from_offset("/tmp/aaa/", "/tmp/aaa/site-packages/pytz/__init__.py"),
+            expected
+        );
+    }
+}

--- a/crates/python_extractor/src/lib.rs
+++ b/crates/python_extractor/src/lib.rs
@@ -2,6 +2,8 @@ use anyhow::{Context, Result};
 use bzl_gen_build_python_utilities::PythonProgram;
 use bzl_gen_build_shared_types::api::extracted_data::{DataBlock, ExtractedData};
 use encoding_rs::*;
+use lazy_static::lazy_static;
+use regex::Regex;
 use std::{
     collections::{BTreeSet, HashMap, HashSet},
     io::{BufRead, Read},
@@ -11,62 +13,111 @@ use std::{
 mod extract_py_bzl_gen_build_commands;
 mod extract_py_imports;
 
-fn get_codec_map() -> HashMap<&'static str, &'static Encoding> {
-    let mut codecs: HashMap<&str, &Encoding> = HashMap::new();
-    codecs.insert("BIG5-TW", BIG5);
-    codecs.insert("CSBIG5", BIG5);
-    codecs.insert("EUCJP", EUC_JP);
-    codecs.insert("UJIS", EUC_JP);
-    codecs.insert("U-JIS", EUC_JP);
-    codecs.insert("EUCKR", EUC_KR);
-    codecs.insert("KOREAN", EUC_KR);
-    codecs.insert("KSC5601", EUC_KR);
-    codecs.insert("KS_C-5601", EUC_KR);
-    codecs.insert("KS_C-5601-1987", EUC_KR);
-    codecs.insert("KS_X-1001", EUC_KR);
-    codecs.insert("EUCKR", EUC_KR);
-    codecs.insert("GB18030-2000", GB18030);
-    codecs.insert("936", GBK);
-    codecs.insert("CP936", GBK);
-    codecs.insert("MS936", GBK);
-    codecs.insert("IBM866", IBM866);
-    codecs.insert("866", IBM866);
-    codecs.insert("ISO-2022-JP", ISO_2022_JP);
-    codecs.insert("ISO-8859-2", ISO_8859_2);
-    codecs.insert("ISO-8859-3", ISO_8859_3);
-    codecs.insert("ISO-8859-4", ISO_8859_4);
-    codecs.insert("ISO-8859-5", ISO_8859_5);
-    codecs.insert("ISO-8859-6", ISO_8859_6);
-    codecs.insert("ISO-8859-7", ISO_8859_7);
-    codecs.insert("ISO-8859-8", ISO_8859_8);
-    codecs.insert("ISO-8859-8-I", ISO_8859_8);
-    codecs.insert("ISO-8859-10", ISO_8859_10);
-    codecs.insert("ISO-8859-13", ISO_8859_13);
-    codecs.insert("ISO-8859-14", ISO_8859_14);
-    codecs.insert("ISO-8859-15", ISO_8859_15);
-    codecs.insert("ISO-8859-16", ISO_8859_16);
-    codecs.insert("MACINTOSH", MACINTOSH);
-    codecs.insert("UTF-8", UTF_8);
-    codecs.insert("U8", UTF_8);
-    codecs.insert("UTF8", UTF_8);
-    codecs.insert("UTF-8", UTF_8);
-    codecs.insert("UTF-8", UTF_8);
-    codecs.insert("U8", UTF_8);
-    codecs.insert("UTF8", UTF_8);
-    codecs.insert("UTF-8", UTF_8);
-    codecs.insert("UTF-16BE", UTF_16BE);
-    codecs.insert("UTF-16LE", UTF_16LE);
-    codecs.insert("WINDOWS-874", WINDOWS_874);
-    codecs.insert("WINDOWS-1250", WINDOWS_1250);
-    codecs.insert("WINDOWS-1251", WINDOWS_1251);
-    codecs.insert("WINDOWS-1252", WINDOWS_1252);
-    codecs.insert("WINDOWS-1253", WINDOWS_1253);
-    codecs.insert("WINDOWS-1254", WINDOWS_1254);
-    codecs.insert("WINDOWS-1255", WINDOWS_1255);
-    codecs.insert("WINDOWS-1256", WINDOWS_1256);
-    codecs.insert("WINDOWS-1257", WINDOWS_1257);
-    codecs.insert("WINDOWS-1258", WINDOWS_1258);
-    codecs
+lazy_static! {
+    static ref CODECS: HashMap<&'static str, &'static Encoding> = {
+        let mut codecs: HashMap<&str, &Encoding> = HashMap::new();
+        codecs.insert("BIG5-TW", BIG5);
+        codecs.insert("CSBIG5", BIG5);
+        codecs.insert("EUCJP", EUC_JP);
+        codecs.insert("UJIS", EUC_JP);
+        codecs.insert("U-JIS", EUC_JP);
+        codecs.insert("EUCKR", EUC_KR);
+        codecs.insert("KOREAN", EUC_KR);
+        codecs.insert("KSC5601", EUC_KR);
+        codecs.insert("KS_C-5601", EUC_KR);
+        codecs.insert("KS_C-5601-1987", EUC_KR);
+        codecs.insert("KS_X-1001", EUC_KR);
+        codecs.insert("EUCKR", EUC_KR);
+        codecs.insert("GB18030-2000", GB18030);
+        codecs.insert("936", GBK);
+        codecs.insert("CP936", GBK);
+        codecs.insert("MS936", GBK);
+        codecs.insert("IBM866", IBM866);
+        codecs.insert("866", IBM866);
+        codecs.insert("ISO-2022-JP", ISO_2022_JP);
+        codecs.insert("ISO-8859-2", ISO_8859_2);
+        codecs.insert("ISO-8859-3", ISO_8859_3);
+        codecs.insert("ISO-8859-4", ISO_8859_4);
+        codecs.insert("ISO-8859-5", ISO_8859_5);
+        codecs.insert("ISO-8859-6", ISO_8859_6);
+        codecs.insert("ISO-8859-7", ISO_8859_7);
+        codecs.insert("ISO-8859-8", ISO_8859_8);
+        codecs.insert("ISO-8859-8-I", ISO_8859_8);
+        codecs.insert("ISO-8859-10", ISO_8859_10);
+        codecs.insert("ISO-8859-13", ISO_8859_13);
+        codecs.insert("ISO-8859-14", ISO_8859_14);
+        codecs.insert("ISO-8859-15", ISO_8859_15);
+        codecs.insert("ISO-8859-16", ISO_8859_16);
+        codecs.insert("MACINTOSH", MACINTOSH);
+        codecs.insert("UTF-8", UTF_8);
+        codecs.insert("U8", UTF_8);
+        codecs.insert("UTF8", UTF_8);
+        codecs.insert("UTF-8", UTF_8);
+        codecs.insert("U8", UTF_8);
+        codecs.insert("UTF8", UTF_8);
+        codecs.insert("UTF-16BE", UTF_16BE);
+        codecs.insert("UTF-16LE", UTF_16LE);
+        codecs.insert("WINDOWS-874", WINDOWS_874);
+        codecs.insert("WINDOWS-1250", WINDOWS_1250);
+        codecs.insert("WINDOWS-1251", WINDOWS_1251);
+        codecs.insert("WINDOWS-1252", WINDOWS_1252);
+        codecs.insert("WINDOWS-1253", WINDOWS_1253);
+        codecs.insert("WINDOWS-1254", WINDOWS_1254);
+        codecs.insert("WINDOWS-1255", WINDOWS_1255);
+        codecs.insert("WINDOWS-1256", WINDOWS_1256);
+        codecs.insert("WINDOWS-1257", WINDOWS_1257);
+        codecs.insert("WINDOWS-1258", WINDOWS_1258);
+        codecs
+    };
+}
+
+pub fn read_file_to_str(input_file: &PathBuf) -> Result<String, anyhow::Error> {
+    let mut file = std::fs::File::open(input_file).with_context(|| {
+        format!(
+            "While attempting to open file: {:?
+        }",
+            input_file
+        )
+    })?;
+
+    let mut buffer = Vec::new();
+    file.read_to_end(&mut buffer).with_context(|| {
+        format!(
+            "While attempting to read file: {:?
+        }",
+            input_file
+        )
+    })?;
+
+    let mut reader = std::io::BufReader::new(&buffer[..]);
+    let mut first_line = String::new();
+    reader.read_line(&mut first_line).with_context(|| {
+        format!(
+            "While attempting to read first line from file to check for encoding: {:?
+            }",
+            input_file
+        )
+    })?;
+
+    let re = Regex::new(r".*#.*\bcoding[=:]\s*([-\w.]+)")?;
+    let encoding = match re.captures(&first_line) {
+        Some(caps) => {
+            let capture = caps
+                .get(1)
+                .with_context(|| "While attempting to read encoding alias")?;
+            let alias = capture.as_str().trim().to_uppercase();
+            CODECS.get(alias.as_str()).unwrap_or(&UTF_8)
+        }
+        None => UTF_8,
+    };
+
+    match encoding {
+        enc if enc == UTF_8 => Ok(String::from_utf8_lossy(&buffer).into_owned()),
+        _ => {
+            let (cow, _, _) = encoding.decode(&buffer);
+            Ok(cow.to_string())
+        }
+    }
 }
 
 pub async fn extract_python(
@@ -90,7 +141,6 @@ pub async fn extract_python(
     relative_input_paths.sort();
 
     let mut data_blocks: Vec<DataBlock> = Default::default();
-    let codecs = get_codec_map();
 
     for relative_path in relative_input_paths {
         let input_file = working_directory.join(&relative_path);
@@ -98,50 +148,7 @@ pub async fn extract_python(
         let mut defs: BTreeSet<String> = Default::default();
         let mut bzl_gen_build_commands: HashSet<String> = Default::default();
 
-        let mut file = std::fs::File::open(&input_file).with_context(|| {
-            format!(
-                "While attempting to open file: {:?
-        }",
-                input_file
-            )
-        })?;
-
-        let mut buffer = Vec::new();
-        file.read_to_end(&mut buffer).with_context(|| {
-            format!(
-                "While attempting to read file: {:?
-        }",
-                input_file
-            )
-        })?;
-
-        let mut reader = std::io::BufReader::new(&buffer[..]);
-        let mut first_line = String::new();
-        reader.read_line(&mut first_line).with_context(|| {
-            format!(
-                "While attempting to read first line from file to check for encoding: {:?
-            }",
-                input_file
-            )
-        })?;
-
-        let encoding = if first_line.starts_with("# coding:") {
-            let alias = first_line
-                .trim_start_matches("# coding:")
-                .trim()
-                .to_uppercase();
-            codecs.get(alias.as_str()).unwrap_or(&UTF_8)
-        } else {
-            UTF_8
-        };
-
-        let input_str = match encoding {
-            enc if enc == UTF_8 => String::from_utf8_lossy(&buffer).into_owned(),
-            _ => {
-                let (cow, _, _) = encoding.decode(&buffer);
-                cow.to_string()
-            }
-        };
+        let input_str = read_file_to_str(&input_file)?;
 
         bzl_gen_build_commands.extend(extract_py_bzl_gen_build_commands::extract(
             input_str.as_str(),

--- a/crates/python_extractor/src/lib.rs
+++ b/crates/python_extractor/src/lib.rs
@@ -1,17 +1,73 @@
+use anyhow::{Context, Result};
+use bzl_gen_build_python_utilities::PythonProgram;
+use bzl_gen_build_shared_types::api::extracted_data::{DataBlock, ExtractedData};
+use encoding_rs::*;
 use std::{
-    collections::{BTreeSet, HashSet},
-    io::Read,
+    collections::{BTreeSet, HashMap, HashSet},
+    io::{BufRead, Read},
     path::PathBuf,
 };
 
-use bzl_gen_build_python_utilities::PythonProgram;
-
-use bzl_gen_build_shared_types::api::extracted_data::{DataBlock, ExtractedData};
-
-use anyhow::{Context, Result};
-
 mod extract_py_bzl_gen_build_commands;
 mod extract_py_imports;
+
+fn get_codec_map() -> HashMap<&'static str, &'static Encoding> {
+    let mut codecs: HashMap<&str, &Encoding> = HashMap::new();
+    codecs.insert("BIG5-TW", BIG5);
+    codecs.insert("CSBIG5", BIG5);
+    codecs.insert("EUCJP", EUC_JP);
+    codecs.insert("UJIS", EUC_JP);
+    codecs.insert("U-JIS", EUC_JP);
+    codecs.insert("EUCKR", EUC_KR);
+    codecs.insert("KOREAN", EUC_KR);
+    codecs.insert("KSC5601", EUC_KR);
+    codecs.insert("KS_C-5601", EUC_KR);
+    codecs.insert("KS_C-5601-1987", EUC_KR);
+    codecs.insert("KS_X-1001", EUC_KR);
+    codecs.insert("EUCKR", EUC_KR);
+    codecs.insert("GB18030-2000", GB18030);
+    codecs.insert("936", GBK);
+    codecs.insert("CP936", GBK);
+    codecs.insert("MS936", GBK);
+    codecs.insert("IBM866", IBM866);
+    codecs.insert("866", IBM866);
+    codecs.insert("ISO-2022-JP", ISO_2022_JP);
+    codecs.insert("ISO-8859-2", ISO_8859_2);
+    codecs.insert("ISO-8859-3", ISO_8859_3);
+    codecs.insert("ISO-8859-4", ISO_8859_4);
+    codecs.insert("ISO-8859-5", ISO_8859_5);
+    codecs.insert("ISO-8859-6", ISO_8859_6);
+    codecs.insert("ISO-8859-7", ISO_8859_7);
+    codecs.insert("ISO-8859-8", ISO_8859_8);
+    codecs.insert("ISO-8859-8-I", ISO_8859_8);
+    codecs.insert("ISO-8859-10", ISO_8859_10);
+    codecs.insert("ISO-8859-13", ISO_8859_13);
+    codecs.insert("ISO-8859-14", ISO_8859_14);
+    codecs.insert("ISO-8859-15", ISO_8859_15);
+    codecs.insert("ISO-8859-16", ISO_8859_16);
+    codecs.insert("MACINTOSH", MACINTOSH);
+    codecs.insert("UTF-8", UTF_8);
+    codecs.insert("U8", UTF_8);
+    codecs.insert("UTF8", UTF_8);
+    codecs.insert("UTF-8", UTF_8);
+    codecs.insert("UTF-8", UTF_8);
+    codecs.insert("U8", UTF_8);
+    codecs.insert("UTF8", UTF_8);
+    codecs.insert("UTF-8", UTF_8);
+    codecs.insert("UTF-16BE", UTF_16BE);
+    codecs.insert("UTF-16LE", UTF_16LE);
+    codecs.insert("WINDOWS-874", WINDOWS_874);
+    codecs.insert("WINDOWS-1250", WINDOWS_1250);
+    codecs.insert("WINDOWS-1251", WINDOWS_1251);
+    codecs.insert("WINDOWS-1252", WINDOWS_1252);
+    codecs.insert("WINDOWS-1253", WINDOWS_1253);
+    codecs.insert("WINDOWS-1254", WINDOWS_1254);
+    codecs.insert("WINDOWS-1255", WINDOWS_1255);
+    codecs.insert("WINDOWS-1256", WINDOWS_1256);
+    codecs.insert("WINDOWS-1257", WINDOWS_1257);
+    codecs.insert("WINDOWS-1258", WINDOWS_1258);
+    codecs
+}
 
 pub async fn extract_python(
     relative_input_paths: String,
@@ -34,6 +90,7 @@ pub async fn extract_python(
     relative_input_paths.sort();
 
     let mut data_blocks: Vec<DataBlock> = Default::default();
+    let codecs = get_codec_map();
 
     for relative_path in relative_input_paths {
         let input_file = working_directory.join(&relative_path);
@@ -44,20 +101,47 @@ pub async fn extract_python(
         let mut file = std::fs::File::open(&input_file).with_context(|| {
             format!(
                 "While attempting to open file: {:?
-    }",
-                input_file
-            )
-        })?;
-        let mut buffer = Vec::new();
-        file.read_to_end(&mut buffer).with_context(|| {
-            format!(
-                "While attempting to read file: {:?
-    }",
+        }",
                 input_file
             )
         })?;
 
-        let input_str = String::from_utf8_lossy(&buffer).into_owned();
+        let mut buffer = Vec::new();
+        file.read_to_end(&mut buffer).with_context(|| {
+            format!(
+                "While attempting to read file: {:?
+        }",
+                input_file
+            )
+        })?;
+
+        let mut reader = std::io::BufReader::new(&buffer[..]);
+        let mut first_line = String::new();
+        reader.read_line(&mut first_line).with_context(|| {
+            format!(
+                "While attempting to read first line from file to check for encoding: {:?
+            }",
+                input_file
+            )
+        })?;
+
+        let encoding = if first_line.starts_with("# coding:") {
+            let alias = first_line
+                .trim_start_matches("# coding:")
+                .trim()
+                .to_uppercase();
+            codecs.get(alias.as_str()).unwrap_or(&UTF_8)
+        } else {
+            UTF_8
+        };
+
+        let input_str = match encoding {
+            enc if enc == UTF_8 => String::from_utf8_lossy(&buffer).into_owned(),
+            _ => {
+                let (cow, _, _) = encoding.decode(&buffer);
+                cow.to_string()
+            }
+        };
 
         bzl_gen_build_commands.extend(extract_py_bzl_gen_build_commands::extract(
             input_str.as_str(),
@@ -149,7 +233,6 @@ mod tests {
     fn expand_path_to_defs_test() {
         let mut expected = vec!["src.main.python.blah.ppp"];
         expected.sort();
-        expected.dedup();
 
         assert_eq!(
             expand_path_to_defs("/Users/foo/bar/src/main/python/blah/ppp.py"),
@@ -161,7 +244,6 @@ mod tests {
     fn expand_path_to_defs_ambigious_path_test() {
         let mut expected = vec!["src.main.python.blah.src.main.ppp", "src.main.ppp"];
         expected.sort();
-        expected.dedup();
 
         assert_eq!(
             expand_path_to_defs("/Users/foo/bar/src/main/python/blah/src/main/ppp.py"),
@@ -173,7 +255,6 @@ mod tests {
     fn expand_site_packages_path_to_defs_test() {
         let mut expected = vec!["pytz", "pytz.__init__"];
         expected.sort();
-        expected.dedup();
 
         assert_eq!(
             expand_path_to_defs_from_offset("/tmp/aaa/", "/tmp/aaa/site-packages/pytz/__init__.py"),

--- a/crates/python_extractor/src/main.rs
+++ b/crates/python_extractor/src/main.rs
@@ -1,20 +1,10 @@
-use std::{
-    collections::{BTreeSet, HashSet},
-    path::PathBuf,
-    time::Instant,
-};
-
-use bzl_gen_build_python_utilities::PythonProgram;
-
-use bzl_gen_build_shared_types::api::extracted_data::{DataBlock, ExtractedData};
+use anyhow::Result;
 use clap::Parser;
-
-use anyhow::{Context, Result};
-
 use log::debug;
+use std::path::PathBuf;
+use std::time::Instant;
 
-mod extract_py_bzl_gen_build_commands;
-mod extract_py_imports;
+use bzl_gen_python_extractor as pe;
 
 #[derive(Parser, Debug)]
 #[command(author, version, about, long_about = None)]
@@ -56,156 +46,16 @@ async fn main() -> Result<()> {
 
     let start_time = Instant::now();
 
-    let mut relative_input_paths: Vec<String> =
-        if let Some(suffix) = opt.relative_input_paths.strip_prefix('@') {
-            std::fs::read_to_string(PathBuf::from(suffix))?
-                .lines()
-                .map(|e| e.to_string())
-                .collect()
-        } else {
-            vec![opt.relative_input_paths.clone()]
-        };
-
-    relative_input_paths.sort();
-
-    let mut data_blocks: Vec<DataBlock> = Default::default();
-
-    for relative_path in relative_input_paths {
-        let input_file = opt.working_directory.join(&relative_path);
-        let mut refs: HashSet<String> = Default::default();
-        let mut defs: BTreeSet<String> = Default::default();
-        let mut bzl_gen_build_commands: HashSet<String> = Default::default();
-
-        let input_str = std::fs::read_to_string(&input_file).with_context(|| {
-            format!(
-                "While attempting to load up file: {:?
-    }",
-                input_file
-            )
-        })?;
-
-        bzl_gen_build_commands.extend(extract_py_bzl_gen_build_commands::extract(
-            input_str.as_str(),
-        ));
-
-        if !opt.disable_ref_generation {
-            let program = PythonProgram::parse(&input_str, "foo.py").with_context(|| {
-                format!(
-                    "Error while parsing file {:?
-        }",
-                    input_file
-                )
-            })?;
-
-            refs.extend(extract_py_imports::extract(&program));
-        }
-
-        let file_p = input_file.to_string_lossy();
-
-        if let Some(rel) = opt.import_path_relative_from.as_ref() {
-            defs.extend(expand_path_to_defs_from_offset(rel, file_p.as_ref()));
-        } else {
-            defs.extend(expand_path_to_defs(file_p.as_ref()));
-        }
-        data_blocks.push(DataBlock {
-            entity_path: relative_path,
-            defs,
-            refs,
-            bzl_gen_build_commands,
-        })
-    }
-
-    let def_refs = ExtractedData {
-        label_or_repo_path: opt.label_or_repo_path.clone(),
-        data_blocks,
-    };
-
-    tokio::fs::write(opt.output, serde_json::to_string_pretty(&def_refs)?).await?;
+    pe::extract_python(
+        opt.relative_input_paths,
+        opt.working_directory,
+        opt.output,
+        opt.label_or_repo_path,
+        opt.disable_ref_generation,
+        opt.import_path_relative_from,
+    )
+    .await?;
 
     debug!("took {:?}", start_time.elapsed());
     Ok(())
-}
-
-fn expand_path_to_defs_from_offset(from_given_path: &str, path: &str) -> Vec<String> {
-    // rules_python Bzlmod support uses pip-tools, which I think places the 3rdparty
-    // source files inside a site-packages/ directory, per module.
-    if let Some(rem) = path
-        .strip_prefix(from_given_path)
-        .and_then(|p| Some(p.strip_prefix("site-packages/").unwrap_or(p)))
-    {
-        if let Some(e) = rem.strip_suffix(".py") {
-            let targ = e.replace('/', ".");
-
-            if let Some(p) = targ.strip_suffix(".__init__") {
-                return vec![p.to_string(), targ.clone()];
-            } else {
-                return vec![targ];
-            }
-        }
-    }
-    Vec::default()
-}
-
-fn expand_path_to_defs(path: &str) -> Vec<String> {
-    let mut results = Vec::default();
-    for element in path.split('/') {
-        results = results
-            .into_iter()
-            .map(|r| format!("{}.{}", r, element))
-            .collect();
-
-        if element == "src" {
-            results.push("src".to_string());
-        }
-    }
-
-    let mut results: Vec<String> = results
-        .into_iter()
-        .map(|e| e.strip_suffix(".py").map(|e| e.to_string()).unwrap_or(e))
-        .collect();
-
-    results.sort();
-    results.dedup();
-    results
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn expand_path_to_defs_test() {
-        let mut expected = vec!["src.main.python.blah.ppp"];
-        expected.sort();
-        expected.dedup();
-
-        assert_eq!(
-            expand_path_to_defs("/Users/foo/bar/src/main/python/blah/ppp.py"),
-            expected
-        );
-    }
-
-    #[test]
-    fn expand_path_to_defs_ambigious_path_test() {
-        let mut expected = vec!["src.main.python.blah.src.main.ppp", "src.main.ppp"];
-        expected.sort();
-        expected.dedup();
-
-        assert_eq!(
-            expand_path_to_defs("/Users/foo/bar/src/main/python/blah/src/main/ppp.py"),
-            expected
-        );
-    }
-
-    #[test]
-    fn expand_site_packages_path_to_defs_test() {
-        let mut expected = vec!["pytz", "pytz.__init__"];
-        expected.sort();
-        expected.dedup();
-
-        assert_eq!(
-            expand_path_to_defs_from_offset("/tmp/aaa/", "/tmp/aaa/site-packages/pytz/__init__.py"),
-            expected
-        );
-    }
 }

--- a/crates/python_extractor/tests/data/nonascii.py
+++ b/crates/python_extractor/tests/data/nonascii.py
@@ -1,0 +1,4 @@
+# coding: iso-8859-5
+# (Unlikely to be the default encoding for most testers.)
+# ±¶ÿאבגדהוזחטיךכלםמן <- Cyrillic characters
+u = "®גנÄ"

--- a/crates/python_extractor/tests/data/test_module.py
+++ b/crates/python_extractor/tests/data/test_module.py
@@ -1,0 +1,16 @@
+from binascii import b2a_base64, hexlify
+import html
+import json
+import mimetypes
+import os
+import struct
+import warnings
+from copy import deepcopy
+from os.path import splitext
+from pathlib import Path, PurePath
+
+from IPython.utils.py3compat import cast_unicode
+from IPython.testing.skipdoctest import skip_doctest
+
+if __name__ == "__main__":
+    pass

--- a/crates/python_extractor/tests/integration_test.rs
+++ b/crates/python_extractor/tests/integration_test.rs
@@ -1,0 +1,115 @@
+use std::fs::File;
+use std::io::BufReader;
+use std::path::PathBuf;
+use tempfile::tempdir;
+
+use bzl_gen_build_shared_types::api::extracted_data::ExtractedData;
+use bzl_gen_python_extractor as pe;
+
+#[tokio::test]
+async fn process_well_formatted_python_module() {
+    let tmpdir = tempdir().expect("Failed to create temp directory");
+    let tmp_path = format!(
+        "python_extractor_output_well_formatted_{}.json",
+        std::time::SystemTime::now().elapsed().unwrap().as_nanos()
+    );
+    let tmp_json_path = tmpdir.path().join(tmp_path);
+
+    pe::extract_python(
+        "test_module.py".to_string(),
+        PathBuf::from("tests/data/"),
+        tmp_json_path.clone(),
+        "@pip".to_string(),
+        false,
+        None,
+    )
+    .await
+    .unwrap();
+
+    let file = File::open(tmp_json_path).unwrap();
+    let reader = BufReader::new(file);
+    let data: ExtractedData = serde_json::from_reader(reader).unwrap();
+
+    let expected_data = r#"
+        {
+            "data_blocks": [
+                {
+                    "entity_path": "test_module.py",
+                    "defs": [],
+                    "refs": [
+                        "binascii",
+                        "html",
+                        "json",
+                        "IPython.testing",
+                        "binascii.b2a_base64",
+                        "os.path",
+                        "pathlib.PurePath",
+                        "warnings",
+                        "IPython.testing.skipdoctest.skip_doctest",
+                        "IPython.utils.py3compat",
+                        "IPython",
+                        "mimetypes",
+                        "IPython.utils",
+                        "pathlib.Path",
+                        "IPython.testing.skipdoctest",
+                        "os",
+                        "IPython.utils.py3compat.cast_unicode",
+                        "copy.deepcopy",
+                        "os.path.splitext",
+                        "pathlib",
+                        "struct",
+                        "copy",
+                        "binascii.hexlify"
+                    ],
+                    "bzl_gen_build_commands": []
+                }
+            ],
+            "label_or_repo_path": "@pip"
+        }
+        "#;
+
+    let expected: ExtractedData = serde_json::from_str(expected_data).unwrap();
+    assert!(expected == data)
+}
+
+#[tokio::test]
+async fn process_non_utf8_python_module() {
+    let tmpdir = tempdir().expect("Failed to create temp directory");
+    let tmp_path = format!(
+        "python_extractor_output_well_formatted_{}.json",
+        std::time::SystemTime::now().elapsed().unwrap().as_nanos()
+    );
+    let tmp_json_path = tmpdir.path().join(tmp_path);
+
+    pe::extract_python(
+        "nonascii.py".to_string(),
+        PathBuf::from("tests/data/"),
+        tmp_json_path.clone(),
+        "@pip".to_string(),
+        false,
+        None,
+    )
+    .await
+    .unwrap();
+
+    let file = File::open(tmp_json_path).unwrap();
+    let reader = BufReader::new(file);
+    let data: ExtractedData = serde_json::from_reader(reader).unwrap();
+
+    let expected_data = r#"
+        {
+            "data_blocks": [
+                {
+                    "entity_path": "nonascii.py",
+                    "defs": [],
+                    "refs": [],
+                    "bzl_gen_build_commands": []
+                }
+            ],
+            "label_or_repo_path": "@pip"
+        }
+        "#;
+
+    let expected: ExtractedData = serde_json::from_str(expected_data).unwrap();
+    assert!(expected == data)
+}

--- a/crates/shared_types/src/api/extracted_data.rs
+++ b/crates/shared_types/src/api/extracted_data.rs
@@ -2,7 +2,7 @@ use std::collections::{BTreeSet, HashSet};
 
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ExtractedData {
     pub data_blocks: Vec<DataBlock>,
     pub label_or_repo_path: String,


### PR DESCRIPTION
When we tried to add IPython as a dependency, the python_extractor blew up trying to read the nonascii.py file that's now part of the test cases in this PR. 

I had to do a bunch of refactoring to make this more testable- the actual code changes aren't that big, but I did need to move some things into lib.rs. I'll note below where my actual changes are. 