### PR TITLE
Minor cleanups

### DIFF
--- a/crates/driver/src/build_graph.rs
+++ b/crates/driver/src/build_graph.rs
@@ -678,7 +678,7 @@ async fn load_initial_graph(
 
         forward_map.insert(m.clone(), idx);
         let node_external_state = NodeExternalState {
-            name: m.clone(),
+            name: m,
             node_type: NodeType::RealNode,
             binary_refs: binary_ref_directives,
             manual_refs: manual_ref_directives,
@@ -818,7 +818,7 @@ pub async fn build_graph(
     for li in load_i {
         let li = li.await??;
         for p in li.defs.into_iter() {
-            all_defs.entry(Arc::new(p.clone())).or_insert(ref_idx);
+            all_defs.entry(Arc::new(p)).or_insert(ref_idx);
             ref_idx += 1;
         }
     }
@@ -851,7 +851,7 @@ pub async fn build_graph(
     let mut graph = load_initial_graph(
         &extracted_mappings,
         &configured_entity_directives,
-        all_defs.clone(),
+        all_defs,
         concurrent_io_operations,
     )
     .await?;
@@ -897,10 +897,9 @@ pub async fn build_graph(
                 .get(&child_node)
                 .expect("Graph invalid if missing");
             if node_state.node_type == NodeType::RealNode {
-                output_node.child_nodes.insert(
-                    node_state.name.as_str().to_string(),
-                    node_state.as_ref().into(),
-                );
+                output_node
+                    .child_nodes
+                    .insert(node_state.name.as_ref().clone(), node_state.as_ref().into());
             }
         }
 

--- a/crates/driver/src/main.rs
+++ b/crates/driver/src/main.rs
@@ -106,10 +106,7 @@ where
     let mut contents = String::new();
     file.read_to_string(&mut contents)?;
 
-    let v: T = serde_json::from_str(contents.as_str())?;
-
-    drop(contents);
-    Ok(v)
+    Ok(serde_json::from_str(contents.as_str())?)
 }
 
 pub async fn async_read_json_file<T>(p: &Path) -> Result<T>
@@ -123,26 +120,21 @@ where
     let mut contents = String::with_capacity(file_len as usize);
     file.read_to_string(&mut contents).await?;
 
-    let v: T = serde_json::from_str(contents.as_str())?;
-
-    drop(contents);
-    Ok(v)
+    Ok(serde_json::from_str(contents.as_str())?)
 }
 
 pub fn write_json_file<T>(p: &Path, value: T) -> Result<()>
 where
     T: serde::Serialize,
 {
-    std::fs::write(p, serde_json::to_string_pretty(&value)?)?;
-    Ok(())
+    Ok(std::fs::write(p, serde_json::to_string_pretty(&value)?)?)
 }
 
 pub async fn async_write_json_file<T>(p: &Path, value: T) -> Result<()>
 where
     T: serde::Serialize,
 {
-    tokio::fs::write(p, serde_json::to_string_pretty(&value)?).await?;
-    Ok(())
+    Ok(tokio::fs::write(p, serde_json::to_string_pretty(&value)?).await?)
 }
 
 fn maybe_add_working_directory<'a, 'b>(


### PR DESCRIPTION
Two kinds of patterns I cleaned up:

1. remove `spawn(async(` when possible. Sometimes it isn't possible and I added a comment.
2. remove unneeded `clone` calls.