### PR TITLE
Add tests for new python syntax

### DIFF
--- a/crates/python_extractor/src/extract_py_imports.rs
+++ b/crates/python_extractor/src/extract_py_imports.rs
@@ -145,4 +145,27 @@ def my_fn():
         expected.dedup();
         assert_eq!(extract(&parsed), expected)
     }
+
+    #[test]
+    fn test_syntax_constructs() {
+        let python_source = r#"
+from typing import Union
+from foo import perform_cast
+value = 1
+args = [int, float]
+# this is a legal-in-runtime construction
+def perform_cast(value, Union[*args])
+# walrus operator
+x := y := 1
+        "#;
+
+        let parsed = PythonProgram::parse(python_source, "tmp.py").unwrap();
+        let mut expected = vec![
+            "typing.Union".to_string(),
+            "foo.perform_cast".to_string(),
+        ];
+        expected.sort();
+        expected.dedup();
+        assert_eq!(extract(&parsed), expected)
+    }
 }


### PR DESCRIPTION
Hello!

Here are tests that are legal python syntax (i.e. https://github.com/astral-sh/ruff parses it fine) but they are currently failing

```
thread 'extract_py_imports::tests::test_syntax_constructs' panicked at python_extractor/src/extract_py_imports.rs:162:68:
called `Result::unwrap()` on an `Err` value: invalid syntax. Got unexpected token '[' at line 7 column 30
```

I'm not sure that currently used parser is a good long-term choice to avoid that kind of problems.
Maybe we can switch to ruff parser altogether?