### PR TITLE
Fix apply_binaries for Google3

### DIFF
--- a/example/build_tools/lang_support/create_lang_build_files/bazel_python_modules.json
+++ b/example/build_tools/lang_support/create_lang_build_files/bazel_python_modules.json
@@ -14,6 +14,15 @@
             "headers": [],
             "function_name": "py_test",
             "target_name_strategy": "source_file_stem"
+          },
+          "binary_application": {
+            "headers": [
+              {
+                "load_from": "//build_tools/lang_support/python:py_binary.bzl",
+                "load_value": "py_binary"
+              }
+            ],
+            "function_name": "py_binary"
           }
         },
         "main_roots": [

--- a/example/build_tools/lang_support/python/py_binary.bzl
+++ b/example/build_tools/lang_support/python/py_binary.bzl
@@ -1,0 +1,33 @@
+def py_binary(
+        name = None,
+        binary_refs_value = None,
+        owning_library = None,
+        entity_path = None,
+        visibility = None,
+        **kwargs):
+    if name == None:
+        fail("Need to specify name")
+    if owning_library == None:
+        fail("Need to specify owning_library")
+    if entity_path == None:
+        fail("Need to specify entity_path")
+    if visibility == None:
+        fail("Need to specify visibility")
+    idx = entity_path.rindex("/")
+    relative_entity_path = entity_path
+    if idx >= 0:
+        relative_entity_path = entity_path[idx + 1:]
+
+    # buildifier: disable=native-python
+    native.py_binary(
+        name = name,
+        main = relative_entity_path,
+        legacy_create_init = 1,
+        deps = [
+            owning_library,
+        ],
+        srcs = [
+            relative_entity_path,
+        ],
+        visibility = visibility,
+    )

--- a/example/com/example/BUILD.bazel
+++ b/example/com/example/BUILD.bazel
@@ -6,8 +6,8 @@ java_proto_library(name='aa_proto_java', deps=[':aa_proto'], visibility=['//visi
 py_proto_library(name='aa_proto_py', deps=[':aa_proto'], visibility=['//visibility:public'])
 # ---- END BZL_GEN_BUILD_GENERATED_CODE ---- no_hash
 # ---- BEGIN BZL_GEN_BUILD_GENERATED_CODE ---- no_hash
+load('//build_tools/lang_support/python:py_binary.bzl', 'py_binary')
+py_binary(name='bin', entity_path='com/example/hello.py', owning_library=':hello', visibility=['//visibility:public'])
 py_library(name='hello', srcs=['hello.py'], deps=['@@//com/example:aa_proto_py', '@@rules_python~0.24.0~pip~pip_39_pandas//:pkg'], visibility=['//visibility:public'])
-# ---- END BZL_GEN_BUILD_GENERATED_CODE ---- no_hash
-# ---- BEGIN BZL_GEN_BUILD_GENERATED_CODE ---- no_hash
 py_test(name='hello_test', srcs=['hello_test.py'], deps=['//com/example:hello'], visibility=['//visibility:public'])
 # ---- END BZL_GEN_BUILD_GENERATED_CODE ---- no_hash

--- a/example/com/example/hello.py
+++ b/example/com/example/hello.py
@@ -6,6 +6,7 @@ FOO = [""]
 def some_data():
     return pd.DataFrame()
 
+# bzl_gen_build:binary_generate:bin
 def main():
     print("Hello World!")
 


### PR DESCRIPTION
**Problem**
When using `--no-aggregate-source` option with py_binary, I noticed that we end up generating py_binary twice, first time for main, and second time for test.

**Solution**
This implements `TargetEntries::combine(ts1, ts2)`, which can dedupliate the target entries based on the name. There's an example in `examples/com` demonstrating the usage.