### PR TITLE
Bump to java 11

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,7 +41,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: temurin
-          java-version: 8
+          java-version: 11
           cache: sbt
       - name: Prepare output
         run: ./.github/ci_scripts/prepare_output.sh bzl-gen-build-${{ matrix.platform }}.tgz staging-directory

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,7 +41,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: temurin
-          java-version: 8
+          java-version: 11
           cache: sbt
       - name: Bazel cache
         uses: actions/cache@v4


### PR DESCRIPTION
CI is failing because github no longer supports jdk 8 in setup-java.

This bumps to 11.