### PR TITLE
Pretty-print BUILD file a la buildifier

### DIFF
--- a/crates/driver/src/print_build.rs
+++ b/crates/driver/src/print_build.rs
@@ -54,6 +54,17 @@ impl TargetEntry {
             kw_args.push((Arc::new("srcs".to_string()), srcs.to_statement()));
         }
 
+        let visibility = self
+            .visibility
+            .as_ref()
+            .map(|e| e.as_ref().as_str())
+            .unwrap_or("//visibility:public");
+
+        kw_args.push((
+            Arc::new("visibility".to_string()),
+            ast_builder::as_py_list(vec![ast_builder::with_constant_str(visibility.to_string())]),
+        ));
+
         for (k, v) in self.extra_kv_pairs.iter() {
             kw_args.push((
                 Arc::new(k.clone()),
@@ -71,17 +82,6 @@ impl TargetEntry {
                 ast_builder::with_constant_str(v.to_string()),
             ));
         }
-
-        let visibility = self
-            .visibility
-            .as_ref()
-            .map(|e| e.as_ref().as_str())
-            .unwrap_or("//visibility:public");
-
-        kw_args.push((
-            Arc::new("visibility".to_string()),
-            ast_builder::as_py_list(vec![ast_builder::with_constant_str(visibility.to_string())]),
-        ));
 
         Ok(ast_builder::as_stmt_expr(
             ast_builder::gen_py_function_call(self.target_type.clone(), Vec::default(), kw_args),
@@ -1137,35 +1137,35 @@ proto_library(
 
 java_proto_library(
     name='a_proto_java',
+    visibility=['//visibility:public'],
     deps=[':a_proto'],
-    visibility=['//visibility:public']
 )
 
 py_proto_library(
     name='a_proto_py',
     srcs=['a.proto'],
+    visibility=['//visibility:public'],
     deps=[],
-    visibility=['//visibility:public']
 )
 
 proto_library(
     name='b_proto',
     srcs=['b.proto'],
+    visibility=['//visibility:public'],
     deps=['//src/main/protos:a_proto'],
-    visibility=['//visibility:public']
 )
 
 java_proto_library(
     name='b_proto_java',
+    visibility=['//visibility:public'],
     deps=[':b_proto'],
-    visibility=['//visibility:public']
 )
 
 py_proto_library(
     name='b_proto_py',
     srcs=['b.proto'],
+    visibility=['//visibility:public'],
     deps=['//src/main/protos:a_proto_py'],
-    visibility=['//visibility:public']
 )
         "#,
             true,
@@ -1219,12 +1219,12 @@ py_proto_library(
 scala_tests(
     name = "scala_extractor",
     srcs = glob(include =  ["*.scala"]),
+    visibility = ["//visibility:public"],
     deps = [
         "//src/main/scala/com/example/scala_extractor",
         "@jvm__io_circe__circe_core//:jar",
         "@jvm__org_scalacheck__scalacheck//:jar",
     ],
-    visibility = ["//visibility:public"],
 )
         "#;
 

--- a/crates/python_utilities/src/ast_printer.rs
+++ b/crates/python_utilities/src/ast_printer.rs
@@ -15,6 +15,7 @@ struct WritingBuffer<'a> {
     buf: Vec<Cow<'a, str>>,
     indent: usize,
     in_line: bool,
+    in_keyword: bool,
 }
 
 impl<'a> WritingBuffer<'a> {
@@ -23,6 +24,7 @@ impl<'a> WritingBuffer<'a> {
             buf: Vec::default(),
             indent: 0,
             in_line: true,
+            in_keyword: false,
         }
     }
     pub fn indent(&mut self) -> &mut Self {
@@ -31,7 +33,7 @@ impl<'a> WritingBuffer<'a> {
     }
 
     pub fn deindent(&mut self) -> &mut Self {
-        self.indent += 1;
+        self.indent -= 1;
         self
     }
 
@@ -39,7 +41,7 @@ impl<'a> WritingBuffer<'a> {
         if !self.in_line {
             self.buf.push(Cow::Borrowed("\n"));
             for _ in 0..self.indent {
-                self.buf.push(Cow::Borrowed("  "))
+                self.buf.push(Cow::Borrowed("    "))
             }
         }
         self.in_line = true;
@@ -52,6 +54,14 @@ impl<'a> WritingBuffer<'a> {
 
     pub fn finish(self) -> String {
         self.buf.join("")
+    }
+
+    pub fn begin_keyword(&mut self) {
+        self.in_keyword = true
+    }
+
+    pub fn finish_keyword(&mut self) {
+        self.in_keyword = false
     }
 }
 
@@ -154,12 +164,155 @@ fn emit_body<'a>(body: &'a [Stmt], str_buffer: &mut WritingBuffer<'a>) {
             }
 
             Stmt::Expr(ast::StmtExpr { range: _, value }) => {
-                str_buffer.push(Cow::Owned(format!("{}", value)));
+                let expr: &ast::Expr = &*value;
+                CustomDisplay::custom_fmt(expr, str_buffer, false);
                 str_buffer.finish_line()
             }
             _ => {
                 panic!("Have not implemented how to print: {:?}", stmt)
             }
+        }
+    }
+}
+
+/**
+ * CustomDisplay represents a mutable pretty printing.
+ * WritingBuffer keep track of the indentation state, so we can't just return string.
+ * This allows, e.g. a nested list items to be double-indented.
+ *
+ * defer - When true, it does not push to str_buffer, and just returns the String value.
+ *         This functionality is partially implemented since we need it only to pick up
+ *         the function name.
+ */
+trait CustomDisplay {
+    fn custom_fmt(&self, str_buffer: &mut WritingBuffer, defer: bool) -> String;
+}
+
+impl CustomDisplay for ast::Expr {
+    fn custom_fmt(&self, str_buffer: &mut WritingBuffer, defer: bool) -> String {
+        fn push(str_buffer: &mut WritingBuffer, defer: bool, s: String) -> String {
+            if !defer {
+                str_buffer.push(Cow::Owned(s.clone()));
+            }
+            s
+        }
+        fn push_inline_list(
+            str_buffer: &mut WritingBuffer,
+            defer: bool,
+            list: &Vec<ast::Expr>,
+        ) -> String {
+            str_buffer.push(Cow::Owned("[".to_string()));
+            let mut idx: usize = 0;
+            for elem in list.iter() {
+                elem.custom_fmt(str_buffer, defer);
+                if idx < list.len() - 1 {
+                    str_buffer.push(Cow::Owned(", ".to_string()))
+                }
+                idx += 1;
+            }
+            str_buffer.push(Cow::Owned("]".to_string()));
+            "".to_string()
+        }
+        fn push_multi_line_list(
+            str_buffer: &mut WritingBuffer,
+            defer: bool,
+            list: &Vec<ast::Expr>,
+        ) -> String {
+            str_buffer.push(Cow::Owned("[".to_string()));
+            str_buffer.finish_line();
+            str_buffer.indent();
+            for elem in list.iter() {
+                elem.custom_fmt(str_buffer, defer);
+                str_buffer.push(Cow::Owned(",".to_string()));
+                str_buffer.finish_line();
+            }
+            str_buffer.deindent();
+            str_buffer.push(Cow::Owned("]".to_string()));
+            "".to_string()
+        }
+
+        match self {
+            // This uses double-quotation for String literals
+            ast::Expr::Constant(ast::ExprConstant { value, .. }) => match value {
+                ast::Constant::Str(str) => push(str_buffer, defer, format!("\"{}\"", str)),
+                _ => push(str_buffer, defer, format!("{}", self)),
+            },
+            ast::Expr::Call(ast::ExprCall {
+                func,
+                args,
+                keywords,
+                ..
+            }) => {
+                let func_expr: &ast::Expr = &*func;
+                let name = func_expr.custom_fmt(str_buffer, true);
+                if name == "load" {
+                    str_buffer.push(Cow::Owned(name));
+                    str_buffer.push(Cow::Owned("(".to_string()));
+                    let mut idx: usize = 0;
+                    for arg in args.iter() {
+                        arg.custom_fmt(str_buffer, defer);
+                        if idx < args.len() - 1 {
+                            str_buffer.push(Cow::Owned(", ".to_string()))
+                        }
+                        idx += 1;
+                    }
+                    idx = 0;
+                    for kw in keywords.iter() {
+                        str_buffer.begin_keyword();
+                        match &kw.arg {
+                            Some(arg) => {
+                                str_buffer.push(Cow::Owned(format!("{} = ", arg)));
+                            }
+                            None => (),
+                        };
+                        kw.value.custom_fmt(str_buffer, defer);
+                        if idx < keywords.len() - 1 {
+                            str_buffer.push(Cow::Owned(", ".to_string()))
+                        }
+                        str_buffer.finish_keyword();
+                        idx += 1;
+                    }
+                    str_buffer.push(Cow::Owned(")".to_string()));
+                } else {
+                    if !str_buffer.in_keyword {
+                        str_buffer.push(Cow::Owned("".to_string()));
+                        str_buffer.finish_line();
+                    } 
+                    str_buffer.push(Cow::Owned(name));
+                    str_buffer.push(Cow::Owned("(".to_string()));
+                    str_buffer.finish_line();
+                    str_buffer.indent();
+                    for arg in args.iter() {
+                        arg.custom_fmt(str_buffer, defer);
+                        str_buffer.push(Cow::Owned(",".to_string()));
+                        str_buffer.finish_line();
+                    }
+                    for kw in keywords.iter() {
+                        str_buffer.begin_keyword();
+                        match &kw.arg {
+                            Some(arg) => {
+                                str_buffer.push(Cow::Owned(format!("{} = ", arg)));
+                            }
+                            None => (),
+                        };
+                        kw.value.custom_fmt(str_buffer, defer);
+                        str_buffer.push(Cow::Owned(",".to_string()));
+                        str_buffer.finish_keyword();
+                        str_buffer.finish_line();
+                    }
+                    str_buffer.deindent();
+                    str_buffer.push(Cow::Owned(")".to_string()));
+                }
+                "".to_string()
+            }
+            ast::Expr::List(ast::ExprList { elts, .. }) => {
+                if elts.len() < 2 {
+                    push_inline_list(str_buffer, defer, elts)
+                } else {
+                    push_multi_line_list(str_buffer, defer, elts)
+                }
+            }
+            _ => push(str_buffer, defer, format!("{}", self)),
         }
     }
 }
@@ -175,16 +328,57 @@ mod tests {
     use super::*;
 
     #[test]
-    fn round_trip_parsing() {
-        let python_source = r#"from tensorflow import foo
-def cust_fn():
-  pass"#;
+    fn round_trip_build_file() {
+        assert_round_trip(
+            r#"load("@rules_proto//proto:defs.bzl", "proto_library")
 
-        let parsed = PythonProgram::parse(python_source, "tmp.py").unwrap();
+proto_library(
+    name = "aa_proto",
+    srcs = ["aa.proto"],
+    deps = [
+        "//x",
+        "//y",
+    ],
+    nested = [
+        ["foo"],
+        ["bar"],
+    ],
+    visibility = ["//visibility:public"],
+)
+
+java_proto_library(
+    name = "a_proto_java",
+    visibility = ["//visibility:public"],
+    deps = [":a_proto"],
+)
+
+filegroup(
+    name = "example_files",
+    srcs = glob(
+        include = ["**/*.java"],
+    ),
+    visibility = ["//visibility:public"],
+)"#,
+        )
+    }
+
+    #[test]
+    fn round_trip_python_source() {
+        assert_round_trip(
+            r#"from tensorflow import foo
+def aa():
+    pass
+def cust_fn():
+    pass"#,
+        )
+    }
+
+    fn assert_round_trip(code: &str) {
+        let parsed = PythonProgram::parse(code, "tmp.py").unwrap();
         let printed_parsed = format!("{}", parsed);
 
         assert_eq!(
-            python_source, printed_parsed,
+            code, printed_parsed,
             "\n\nPrinted parsed was: {}\n\n",
             printed_parsed
         );

--- a/crates/python_utilities/src/ast_printer.rs
+++ b/crates/python_utilities/src/ast_printer.rs
@@ -206,13 +206,11 @@ impl CustomDisplay for ast::Expr {
             list: &Vec<ast::Expr>,
         ) -> String {
             str_buffer.push("[");
-            let mut idx: usize = 0;
-            for elem in list.iter() {
+            for (idx, elem) in list.iter().enumerate() {
                 elem.custom_fmt(str_buffer, defer);
                 if idx < list.len() - 1 {
                     str_buffer.push(", ");
                 }
-                idx += 1;
             }
             str_buffer.push("]");
             "".to_string()
@@ -247,16 +245,13 @@ impl CustomDisplay for ast::Expr {
                 let name = func_expr.custom_fmt(str_buffer, true);
                 if name == "load" {
                     str_buffer.push_cow(Cow::Owned(name)).push("(");
-                    let mut idx: usize = 0;
-                    for arg in args.iter() {
+                    for (idx, arg) in args.iter().enumerate() {
                         arg.custom_fmt(str_buffer, defer);
                         if idx < args.len() - 1 {
                             str_buffer.push(", ");
                         }
-                        idx += 1;
                     }
-                    idx = 0;
-                    for kw in keywords.iter() {
+                    for (idx, kw) in keywords.iter().enumerate() {
                         str_buffer.begin_keyword();
                         match &kw.arg {
                             Some(arg) => {
@@ -269,7 +264,6 @@ impl CustomDisplay for ast::Expr {
                             str_buffer.push(", ");
                         }
                         str_buffer.finish_keyword();
-                        idx += 1;
                     }
                     str_buffer.push(")");
                 } else {

--- a/example/com/example/BUILD.bazel
+++ b/example/com/example/BUILD.bazel
@@ -1,13 +1,49 @@
 # ---- BEGIN BZL_GEN_BUILD_GENERATED_CODE ---- no_hash
-load('@rules_proto//proto:defs.bzl', 'proto_library')
-load('@rules_python//python:proto.bzl', 'py_proto_library')
-proto_library(name='aa_proto', srcs=['aa.proto'], visibility=['//visibility:public'])
-java_proto_library(name='aa_proto_java', deps=[':aa_proto'], visibility=['//visibility:public'])
-py_proto_library(name='aa_proto_py', deps=[':aa_proto'], visibility=['//visibility:public'])
+load("@rules_proto//proto:defs.bzl", "proto_library")
+load("@rules_python//python:proto.bzl", "py_proto_library")
+
+proto_library(
+    name = "aa_proto",
+    srcs = ["aa.proto"],
+    visibility = ["//visibility:public"],
+)
+
+java_proto_library(
+    name = "aa_proto_java",
+    visibility = ["//visibility:public"],
+    deps = [":aa_proto"],
+)
+
+py_proto_library(
+    name = "aa_proto_py",
+    visibility = ["//visibility:public"],
+    deps = [":aa_proto"],
+)
 # ---- END BZL_GEN_BUILD_GENERATED_CODE ---- no_hash
 # ---- BEGIN BZL_GEN_BUILD_GENERATED_CODE ---- no_hash
-load('//build_tools/lang_support/python:py_binary.bzl', 'py_binary')
-py_binary(name='bin', entity_path='com/example/hello.py', owning_library=':hello', visibility=['//visibility:public'])
-py_library(name='hello', srcs=['hello.py'], deps=['@@//com/example:aa_proto_py', '@@rules_python~0.24.0~pip~pip_39_pandas//:pkg'], visibility=['//visibility:public'])
-py_test(name='hello_test', srcs=['hello_test.py'], deps=['//com/example:hello'], visibility=['//visibility:public'])
+load("//build_tools/lang_support/python:py_binary.bzl", "py_binary")
+
+py_binary(
+    name = "bin",
+    visibility = ["//visibility:public"],
+    entity_path = "com/example/hello.py",
+    owning_library = ":hello",
+)
+
+py_library(
+    name = "hello",
+    srcs = ["hello.py"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "@@//com/example:aa_proto_py",
+        "@@rules_python~0.24.0~pip~pip_39_pandas//:pkg",
+    ],
+)
+
+py_test(
+    name = "hello_test",
+    srcs = ["hello_test.py"],
+    visibility = ["//visibility:public"],
+    deps = ["//com/example:hello"],
+)
 # ---- END BZL_GEN_BUILD_GENERATED_CODE ---- no_hash

--- a/example/com/example/foo/BUILD.bazel
+++ b/example/com/example/foo/BUILD.bazel
@@ -1,10 +1,42 @@
 # ---- BEGIN BZL_GEN_BUILD_GENERATED_CODE ---- no_hash
-load('@rules_proto//proto:defs.bzl', 'proto_library')
-load('@rules_python//python:proto.bzl', 'py_proto_library')
-proto_library(name='bb_proto', srcs=['bb.proto'], deps=['//com/example:aa_proto'], visibility=['//visibility:public'])
-java_proto_library(name='bb_proto_java', deps=[':bb_proto'], visibility=['//visibility:public'])
-py_proto_library(name='bb_proto_py', deps=[':bb_proto'], visibility=['//visibility:public'])
-proto_library(name='cc_proto', srcs=['cc.proto'], deps=['//com/example:aa_proto'], visibility=['//visibility:public'])
-java_proto_library(name='cc_proto_java', deps=[':cc_proto'], visibility=['//visibility:public'])
-py_proto_library(name='cc_proto_py', deps=[':cc_proto'], visibility=['//visibility:public'])
+load("@rules_proto//proto:defs.bzl", "proto_library")
+load("@rules_python//python:proto.bzl", "py_proto_library")
+
+proto_library(
+    name = "bb_proto",
+    srcs = ["bb.proto"],
+    visibility = ["//visibility:public"],
+    deps = ["//com/example:aa_proto"],
+)
+
+java_proto_library(
+    name = "bb_proto_java",
+    visibility = ["//visibility:public"],
+    deps = [":bb_proto"],
+)
+
+py_proto_library(
+    name = "bb_proto_py",
+    visibility = ["//visibility:public"],
+    deps = [":bb_proto"],
+)
+
+proto_library(
+    name = "cc_proto",
+    srcs = ["cc.proto"],
+    visibility = ["//visibility:public"],
+    deps = ["//com/example:aa_proto"],
+)
+
+java_proto_library(
+    name = "cc_proto_java",
+    visibility = ["//visibility:public"],
+    deps = [":cc_proto"],
+)
+
+py_proto_library(
+    name = "cc_proto_py",
+    visibility = ["//visibility:public"],
+    deps = [":cc_proto"],
+)
 # ---- END BZL_GEN_BUILD_GENERATED_CODE ---- no_hash

--- a/example/src/main/java/com/example/BUILD.bazel
+++ b/example/src/main/java/com/example/BUILD.bazel
@@ -1,4 +1,20 @@
 # ---- BEGIN BZL_GEN_BUILD_GENERATED_CODE ---- no_hash
-filegroup(name='example_files', srcs=glob(include=['**/*.java']), visibility=['//visibility:public'])
-java_library(name='example', srcs=[':example_files'], deps=['@@//com/example:aa_proto_java', '@@_main~maven~maven//:org_slf4j_slf4j_api'], visibility=['//visibility:public'])
+
+filegroup(
+    name = "example_files",
+    srcs = glob(
+        include = ["**/*.java"],
+    ),
+    visibility = ["//visibility:public"],
+)
+
+java_library(
+    name = "example",
+    srcs = [":example_files"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "@@//com/example:aa_proto_java",
+        "@@_main~maven~maven//:org_slf4j_slf4j_api",
+    ],
+)
 # ---- END BZL_GEN_BUILD_GENERATED_CODE ---- no_hash


### PR DESCRIPTION
Fixes #215

## Problem
Currently we have to run buildifier to pretty print the BUILD file, which takes human-observable time in a decent-size monorepo.

## Solution
This pretty-prints the Python AST a la buildifier style so we don't have to wait.

## Notes

See the `example/` integration test directory.

### Before

```python
# ---- BEGIN BZL_GEN_BUILD_GENERATED_CODE ---- no_hash
filegroup(name='example_files', srcs=glob(include=['**/*.java']), visibility=['//visibility:public'])
java_library(name='example', srcs=[':example_files'], deps=['@@//com/example:aa_proto_java', '@@_main~maven~maven//:org_slf4j_slf4j_api'], visibility=['//visibility:public'])
# ---- END BZL_GEN_BUILD_GENERATED_CODE ---- no_hash
```

### After

```python
# ---- BEGIN BZL_GEN_BUILD_GENERATED_CODE ---- no_hash

filegroup(
    name = "example_files",
    srcs = glob(
        include = ["**/*.java"],
    ),
    visibility = ["//visibility:public"],
)

java_library(
    name = "example",
    srcs = [":example_files"],
    visibility = ["//visibility:public"],
    deps = [
        "@@//com/example:aa_proto_java",
        "@@_main~maven~maven//:org_slf4j_slf4j_api",
    ],
)
# ---- END BZL_GEN_BUILD_GENERATED_CODE ---- no_hash
```

