### PR TITLE
Assume "com" imports are never relative.

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,8 @@ As an optimization, setting the environment variable `BZL_GEN_SPECIAL_TLDS` to a
 export BZL_GEN_SPECIAL_TLDS=com,net,org
 ```
 
+The names must match the regular expression `^[a-z]+$`.
+
 ### Extracting definitions from 3rdparty libraries
 
 Extracting definitions from 3rdparty libraries require some setup, also demonstrated in the `example/` repo.

--- a/README.md
+++ b/README.md
@@ -184,6 +184,16 @@ In some situations, like for Protocol Buffer schemas, we want to generate second
 }
 ```
 
+### Heuristics
+
+Wildcard imports in Java and Scala can be expensive to resolve, since every subsequent import migth be relative to the previous wildcard.
+
+As an optimization, setting the environment variable `BZL_GEN_SPECIAL_TLDS` to a comma-separated list will tell the driver program to assume any import rooted at one of those names is not relative. For example:
+
+```bash
+export BZL_GEN_SPECIAL_TLDS=com,net,org
+```
+
 ### Extracting definitions from 3rdparty libraries
 
 Extracting definitions from 3rdparty libraries require some setup, also demonstrated in the `example/` repo.

--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ In some situations, like for Protocol Buffer schemas, we want to generate second
 
 ### Heuristics
 
-Wildcard imports in Java and Scala can be expensive to resolve, since every subsequent import migth be relative to the previous wildcard.
+Wildcard imports in Java and Scala can be expensive to resolve, since every subsequent import might be relative to the previous wildcard.
 
 As an optimization, setting the environment variable `BZL_GEN_SPECIAL_TLDS` to a comma-separated list will tell the driver program to assume any import rooted at one of those names is not relative. For example:
 

--- a/language_generators/scala-defref-extractor/src/main/scala/io/bazeltools/buildgen/javadefref/JavaSourceEntityExtractor.scala
+++ b/language_generators/scala-defref-extractor/src/main/scala/io/bazeltools/buildgen/javadefref/JavaSourceEntityExtractor.scala
@@ -273,12 +273,16 @@ object JavaSourceEntityExtractor {
     val expand: Entity => LazyList[Entity] =
       optPack match {
         case Some(p) => { (e: Entity) =>
-          if (e.isSingleton) {
+          if (e.parts.head == SpecialCom) {
+            e #:: LazyList.empty
+          } else if (e.isSingleton) {
             e #:: (p / e) #:: wildImp.map(_ / e)
           } else e #:: LazyList.empty
         }
         case None => { (e: Entity) =>
-          if (e.isSingleton) {
+          if (e.parts.head == SpecialCom) {
+            e #:: LazyList.empty
+          } else if (e.isSingleton) {
             e #:: wildImp.map(_ / e)
           } else e #:: LazyList.empty
         }

--- a/language_generators/scala-defref-extractor/src/main/scala/io/bazeltools/buildgen/javadefref/JavaSourceEntityExtractor.scala
+++ b/language_generators/scala-defref-extractor/src/main/scala/io/bazeltools/buildgen/javadefref/JavaSourceEntityExtractor.scala
@@ -273,14 +273,14 @@ object JavaSourceEntityExtractor {
     val expand: Entity => LazyList[Entity] =
       optPack match {
         case Some(p) => { (e: Entity) =>
-          if (e.parts.head == SpecialCom) {
+          if (Entity.isSpecialTld(e.parts.head)) {
             e #:: LazyList.empty
           } else if (e.isSingleton) {
             e #:: (p / e) #:: wildImp.map(_ / e)
           } else e #:: LazyList.empty
         }
         case None => { (e: Entity) =>
-          if (e.parts.head == SpecialCom) {
+          if (Entity.isSpecialTld(e.parts.head)) {
             e #:: LazyList.empty
           } else if (e.isSingleton) {
             e #:: wildImp.map(_ / e)

--- a/language_generators/scala-defref-extractor/src/main/scala/io/bazeltools/buildgen/javadefref/JavaSourceEntityExtractor.scala
+++ b/language_generators/scala-defref-extractor/src/main/scala/io/bazeltools/buildgen/javadefref/JavaSourceEntityExtractor.scala
@@ -20,7 +20,11 @@ import com.github.javaparser.ParseProblemException
  * based on Apache Licensed:
  * https://github.com/pantsbuild/pants/blob/4e7c57db992150b3fc972e684561edb8231bba3d/src/python/pants/backend/java/dependency_inference/PantsJavaParserLauncher.java#L1
  */
-object JavaSourceEntityExtractor {
+case class JavaSourceEntityExtractor(specialTlds: Set[String]) {
+
+  def isSpecialTld(name: String): Boolean =
+    specialTlds(name)
+
   // this is mutable, so we need to guard any access
   private[this] lazy val parser = {
     val config = new ParserConfiguration();
@@ -273,14 +277,14 @@ object JavaSourceEntityExtractor {
     val expand: Entity => LazyList[Entity] =
       optPack match {
         case Some(p) => { (e: Entity) =>
-          if (Entity.isSpecialTld(e.parts.head)) {
+          if (isSpecialTld(e.parts.head)) {
             e #:: LazyList.empty
           } else if (e.isSingleton) {
             e #:: (p / e) #:: wildImp.map(_ / e)
           } else e #:: LazyList.empty
         }
         case None => { (e: Entity) =>
-          if (Entity.isSpecialTld(e.parts.head)) {
+          if (isSpecialTld(e.parts.head)) {
             e #:: LazyList.empty
           } else if (e.isSingleton) {
             e #:: wildImp.map(_ / e)

--- a/language_generators/scala-defref-extractor/src/main/scala/io/bazeltools/buildgen/javadefref/Main.scala
+++ b/language_generators/scala-defref-extractor/src/main/scala/io/bazeltools/buildgen/javadefref/Main.scala
@@ -5,6 +5,6 @@ import io.bazeltools.buildgen.shared.{Symbols, DriverApplication}
 
 object Main extends DriverApplication {
   def name: String = "java_extractor"
-  def extract(data: String): IO[Symbols] =
-    JavaSourceEntityExtractor.extract(data)
+  def extract(data: String, specialTlds: Set[String]): IO[Symbols] =
+    JavaSourceEntityExtractor(specialTlds).extract(data)
 }

--- a/language_generators/scala-defref-extractor/src/main/scala/io/bazeltools/buildgen/scaladefref/Main.scala
+++ b/language_generators/scala-defref-extractor/src/main/scala/io/bazeltools/buildgen/scaladefref/Main.scala
@@ -1,10 +1,12 @@
 package io.bazeltools.buildgen.scaladefref
 
 import cats.effect.IO
-import io.bazeltools.buildgen.shared.{Symbols, DriverApplication}
+import io.bazeltools.buildgen.shared.{DriverApplication, Entity, Symbols}
 
 object Main extends DriverApplication {
   def name: String = "scala_extractor"
-  def extract(data: String): IO[Symbols] =
-    ScalaSourceEntityExtractor.extract(data)
+  def extract(data: String, specialTlds: Set[String]): IO[Symbols] = {
+    val map = Entity.makeSpecialTldsMap(specialTlds)
+    ScalaSourceEntityExtractor(map).extract(data)
+  }
 }

--- a/language_generators/scala-defref-extractor/src/main/scala/io/bazeltools/buildgen/scaladefref/ScalaSourceEntityExtractor.scala
+++ b/language_generators/scala-defref-extractor/src/main/scala/io/bazeltools/buildgen/scaladefref/ScalaSourceEntityExtractor.scala
@@ -22,7 +22,11 @@ import scala.meta.parsers.XtensionParseInputLike
 import cats.syntax.all._
 import io.bazeltools.buildgen.shared.{Entity, PathTree, Symbols}
 
-object ScalaSourceEntityExtractor {
+case class ScalaSourceEntityExtractor(specialTlds: Map[String, Entity.Resolved]) {
+
+  def getSpecialTld(name: String): Option[Entity.Resolved] =
+    specialTlds.get(name)
+
   sealed abstract class Err(message: String) extends Exception(message)
 
   case class ScalaMetaParseException(parseError: Parsed.Error)
@@ -176,7 +180,7 @@ object ScalaSourceEntityExtractor {
         val root = resolve(s)
         nel.tail.foldLeft(root) { (r, p) =>
           val s = fn(p)
-          Entity.getSpecialTld(s) match {
+          getSpecialTld(s) match {
             case Some(resolved) => resolved
             case None           => r / s
           }
@@ -488,7 +492,7 @@ object ScalaSourceEntityExtractor {
             val rWild = uwild.resolve(acc)
 
             { (name: String) =>
-              Entity.getSpecialTld(name) match {
+              getSpecialTld(name) match {
                 case Some(resolved) => resolved
                 case None           => acc(name) | (rWild / name)
               }
@@ -517,7 +521,7 @@ object ScalaSourceEntityExtractor {
         val packRes = ss.packageResolved
 
         { (name: String) =>
-          Entity.getSpecialTld(name) match {
+          getSpecialTld(name) match {
             case Some(resolved) =>
               resolved
             case None =>

--- a/language_generators/scala-defref-extractor/src/main/scala/io/bazeltools/buildgen/scaladefref/ScalaSourceEntityExtractor.scala
+++ b/language_generators/scala-defref-extractor/src/main/scala/io/bazeltools/buildgen/scaladefref/ScalaSourceEntityExtractor.scala
@@ -22,7 +22,9 @@ import scala.meta.parsers.XtensionParseInputLike
 import cats.syntax.all._
 import io.bazeltools.buildgen.shared.{Entity, PathTree, Symbols}
 
-case class ScalaSourceEntityExtractor(specialTlds: Map[String, Entity.Resolved]) {
+case class ScalaSourceEntityExtractor(
+    specialTlds: Map[String, Entity.Resolved]
+) {
 
   def getSpecialTld(name: String): Option[Entity.Resolved] =
     specialTlds.get(name)

--- a/language_generators/scala-defref-extractor/src/main/scala/io/bazeltools/buildgen/scaladefref/ScalaSourceEntityExtractor.scala
+++ b/language_generators/scala-defref-extractor/src/main/scala/io/bazeltools/buildgen/scaladefref/ScalaSourceEntityExtractor.scala
@@ -22,7 +22,7 @@ import scala.meta.parsers.XtensionParseInputLike
 import cats.syntax.all._
 import io.bazeltools.buildgen.shared.{Entity, PathTree, Symbols}
 
-import Entity.{ SpecialCom, SpecialComEntity }
+import Entity.{SpecialCom, SpecialComEntity}
 
 object ScalaSourceEntityExtractor {
   sealed abstract class Err(message: String) extends Exception(message)

--- a/language_generators/scala-defref-extractor/src/main/scala/io/bazeltools/buildgen/shared/DriverApplication.scala
+++ b/language_generators/scala-defref-extractor/src/main/scala/io/bazeltools/buildgen/shared/DriverApplication.scala
@@ -92,7 +92,8 @@ abstract class DriverApplication extends IOApp {
       paths: List[String],
       specialTlds: Set[String]
   ): IO[List[DataBlock]] =
-    if (parallel) parallelExtractDataBlocks(workingDirectory, paths, specialTlds)
+    if (parallel)
+      parallelExtractDataBlocks(workingDirectory, paths, specialTlds)
     else sequentialExtractDataBlocks(workingDirectory, paths, specialTlds)
 
   // We assume that imports starting with special TLD (e.g. "com")

--- a/language_generators/scala-defref-extractor/src/main/scala/io/bazeltools/buildgen/shared/Entity.scala
+++ b/language_generators/scala-defref-extractor/src/main/scala/io/bazeltools/buildgen/shared/Entity.scala
@@ -44,7 +44,9 @@ object Entity {
   implicit val entityDecoder: Decoder[Entity] =
     Decoder.decodeString.map(dotted(_))
 
-  def makeSpecialTldsMap(names: Iterable[String]): Map[String, Entity.Resolved] =
+  def makeSpecialTldsMap(
+      names: Iterable[String]
+  ): Map[String, Entity.Resolved] =
     names.iterator.map { name =>
       (name, Entity.Resolved.Known(Entity.simple(name)))
     }.toMap

--- a/language_generators/scala-defref-extractor/src/test/scala/io/bazeltools/buildgen/javadefref/CanParseFileTest.scala
+++ b/language_generators/scala-defref-extractor/src/test/scala/io/bazeltools/buildgen/javadefref/CanParseFileTest.scala
@@ -7,8 +7,10 @@ import cats.effect.unsafe.implicits.global
 
 class CanParseFileTest extends AnyFunSuite {
 
-  def assertParse(str: String, expected: Symbols) =
-    assert(JavaSourceEntityExtractor.extract(str).unsafeRunSync() === expected)
+  def assertParse(str: String, expected: Symbols) = {
+    val got = JavaSourceEntityExtractor(Set.empty).extract(str).unsafeRunSync()
+    assert(got === expected)
+  }
 
   test("can extract a simple file") {
     val simpleContent = """

--- a/language_generators/scala-defref-extractor/src/test/scala/io/bazeltools/buildgen/javadefref/JavaSourceEntityExtractorTest.scala
+++ b/language_generators/scala-defref-extractor/src/test/scala/io/bazeltools/buildgen/javadefref/JavaSourceEntityExtractorTest.scala
@@ -11,7 +11,7 @@ class JavaSourceEntityExtractorTest extends munit.CatsEffectSuite {
   case class DefsRefs(defs: SortedSet[Entity], refs: SortedSet[Entity])
 
   def extractString(in: String): IO[Symbols] =
-    JavaSourceEntityExtractor.extract(in)
+    JavaSourceEntityExtractor(Set.empty).extract(in)
 
   def ents(s: String): SortedSet[Entity] =
     decode[List[Entity]](s).map(_.to(SortedSet)) match {

--- a/language_generators/scala-defref-extractor/src/test/scala/io/bazeltools/buildgen/scaladefref/CanParseFileTest.scala
+++ b/language_generators/scala-defref-extractor/src/test/scala/io/bazeltools/buildgen/scaladefref/CanParseFileTest.scala
@@ -8,8 +8,8 @@ import cats.effect.unsafe.implicits.global
 class CanParseFileTest extends AnyFunSuite {
 
   def assertParse(str: String, expected: Symbols, specialTlds: List[String]) = {
-    Entity.setSpecialTlds(specialTlds)
-    val got = ScalaSourceEntityExtractor.extract(str).unsafeRunSync()
+    val map = Entity.makeSpecialTldsMap(specialTlds)
+    val got = ScalaSourceEntityExtractor(map).extract(str).unsafeRunSync()
     assert(got === expected)
   }
 

--- a/language_generators/scala-defref-extractor/src/test/scala/io/bazeltools/buildgen/scaladefref/CanParseFileTest.scala
+++ b/language_generators/scala-defref-extractor/src/test/scala/io/bazeltools/buildgen/scaladefref/CanParseFileTest.scala
@@ -58,11 +58,7 @@ class CanParseFileTest extends AnyFunSuite {
         Entity.dotted("com"),
         Entity.dotted("com.example"),
         Entity.dotted("com.example.Elephant"),
-        Entity.dotted("com.example.Wolf"),
-        Entity.dotted("com.foo.bar.com"),
-        Entity.dotted("com.foo.bar.com.example"),
-        Entity.dotted("com.foo.bar.com.example.Elephant"),
-        Entity.dotted("com.foo.bar.com.example.Wolf")
+        Entity.dotted("com.example.Wolf")
       ),
       SortedSet.empty
     )
@@ -327,44 +323,10 @@ trait BaseNode
         Entity.dotted("com.animal.dogs.retriever.CaseClassConfig"),
         Entity.dotted("com.animal.dogs.retriever.Express"),
         Entity.dotted("com.animal.dogs.retriever.JsonEncoder"),
-        Entity.dotted(
-          "com.animal.dogs.retriever.com.animal.cats.big.BaseTrainingNode"
-        ),
-        Entity.dotted("com.animal.dogs.retriever.com.animal.cats.housecat"),
-        Entity.dotted(
-          "com.animal.dogs.retriever.com.animal.cats.housecat.Cuddle"
-        ),
-        Entity.dotted("com.animal.dogs.retriever.com.animal.cats.tiger"),
-        Entity.dotted(
-          "com.animal.dogs.retriever.com.animal.cats.tiger.TigerStripes"
-        ),
-        Entity.dotted("com.animal.dogs.retriever.com.animal.dogs.pugs.Cute"),
-        Entity.dotted("com.animal.dogs.retriever.com.animal.dogs.pugs.Small"),
-        Entity.dotted("com.animal.dogs.retriever.com.animal.dogs.retriever"),
         Entity.dotted("com.animal.dogs.retriever"),
-        Entity.dotted("com.animal.dogs.retriever.com"),
-        Entity.dotted("com.animal.dogs.retriever.com.animal"),
-        Entity.dotted("com.animal.dogs.retriever.com.animal.cats"),
-        Entity.dotted("com.animal.dogs.retriever.com.animal.cats.big"),
-        Entity.dotted("com.animal.dogs.retriever.com.animal.dogs"),
-        Entity.dotted("com.animal.dogs.retriever.com.animal.dogs.pugs"),
         Entity.dotted("com.example.CaseClassConfig"),
         Entity.dotted("com.example.Express"),
-        Entity.dotted("com.example.JsonEncoder"),
-        Entity.dotted("com.example.com"),
-        Entity.dotted("com.example.com.animal"),
-        Entity.dotted("com.example.com.animal.cats"),
-        Entity.dotted("com.example.com.animal.cats.big"),
-        Entity.dotted("com.example.com.animal.cats.big.BaseTrainingNode"),
-        Entity.dotted("com.example.com.animal.cats.housecat"),
-        Entity.dotted("com.example.com.animal.cats.housecat.Cuddle"),
-        Entity.dotted("com.example.com.animal.cats.tiger"),
-        Entity.dotted("com.example.com.animal.cats.tiger.TigerStripes"),
-        Entity.dotted("com.example.com.animal.dogs"),
-        Entity.dotted("com.example.com.animal.dogs.pugs"),
-        Entity.dotted("com.example.com.animal.dogs.pugs.Cute"),
-        Entity.dotted("com.example.com.animal.dogs.pugs.Small"),
-        Entity.dotted("com.example.com.animal.dogs.retriever")
+        Entity.dotted("com.example.JsonEncoder")
       ),
       SortedSet.empty
     )
@@ -409,44 +371,10 @@ object BaseNode
         Entity.dotted("com.animal.dogs.retriever.CaseClassConfig"),
         Entity.dotted("com.animal.dogs.retriever.Express"),
         Entity.dotted("com.animal.dogs.retriever.JsonEncoder"),
-        Entity.dotted(
-          "com.animal.dogs.retriever.com.animal.cats.big.BaseTrainingNode"
-        ),
-        Entity.dotted("com.animal.dogs.retriever.com.animal.cats.housecat"),
-        Entity.dotted(
-          "com.animal.dogs.retriever.com.animal.cats.housecat.Cuddle"
-        ),
-        Entity.dotted("com.animal.dogs.retriever.com.animal.cats.tiger"),
-        Entity.dotted(
-          "com.animal.dogs.retriever.com.animal.cats.tiger.TigerStripes"
-        ),
-        Entity.dotted("com.animal.dogs.retriever.com.animal.dogs.pugs.Cute"),
-        Entity.dotted("com.animal.dogs.retriever.com.animal.dogs.pugs.Small"),
-        Entity.dotted("com.animal.dogs.retriever.com.animal.dogs.retriever"),
         Entity.dotted("com.animal.dogs.retriever"),
-        Entity.dotted("com.animal.dogs.retriever.com"),
-        Entity.dotted("com.animal.dogs.retriever.com.animal"),
-        Entity.dotted("com.animal.dogs.retriever.com.animal.cats"),
-        Entity.dotted("com.animal.dogs.retriever.com.animal.cats.big"),
-        Entity.dotted("com.animal.dogs.retriever.com.animal.dogs"),
-        Entity.dotted("com.animal.dogs.retriever.com.animal.dogs.pugs"),
         Entity.dotted("com.example.CaseClassConfig"),
         Entity.dotted("com.example.Express"),
-        Entity.dotted("com.example.JsonEncoder"),
-        Entity.dotted("com.example.com"),
-        Entity.dotted("com.example.com.animal"),
-        Entity.dotted("com.example.com.animal.cats"),
-        Entity.dotted("com.example.com.animal.cats.big"),
-        Entity.dotted("com.example.com.animal.cats.big.BaseTrainingNode"),
-        Entity.dotted("com.example.com.animal.cats.housecat"),
-        Entity.dotted("com.example.com.animal.cats.housecat.Cuddle"),
-        Entity.dotted("com.example.com.animal.cats.tiger"),
-        Entity.dotted("com.example.com.animal.cats.tiger.TigerStripes"),
-        Entity.dotted("com.example.com.animal.dogs"),
-        Entity.dotted("com.example.com.animal.dogs.pugs"),
-        Entity.dotted("com.example.com.animal.dogs.pugs.Cute"),
-        Entity.dotted("com.example.com.animal.dogs.pugs.Small"),
-        Entity.dotted("com.example.com.animal.dogs.retriever")
+        Entity.dotted("com.example.JsonEncoder")
       ),
       SortedSet.empty
     )
@@ -503,15 +431,8 @@ case class BaseNode() {
         Entity.dotted("com.animal.dogs.retriever"),
         Entity.dotted("com.animal.dogs.retriever.Bar"),
         Entity.dotted("com.example.???"),
-        Entity.dotted("com.example.com"),
-        Entity.dotted("com.example.com.animal"),
-        Entity.dotted("com.example.com.animal.dogs"),
-        Entity.dotted("com.example.com.animal.dogs.retriever"),
-        Entity.dotted("com.example.com.animal.dogs.retriever.Bar"),
         Entity.dotted("com.animal.dogs.gamma"),
         Entity.dotted("com.animal.dogs.gamma.Square"),
-        Entity.dotted("com.example.com.animal.dogs.gamma"),
-        Entity.dotted("com.example.com.animal.dogs.gamma.Square"),
         Entity.dotted("Data"),
         Entity.dotted("Option"),
         Entity.dotted("TypeB"),
@@ -693,17 +614,9 @@ object MyObject {
         Entity.dotted("com.baz.buzz.Dope.Long"),
         Entity.dotted("com.baz.buzz.Dope.Nope"),
         Entity.dotted("com.baz.buzz.Dope.String"),
-        Entity.dotted("com.baz.buzz.Dope.com"),
-        Entity.dotted("com.baz.buzz.Dope.com.baz"),
-        Entity.dotted("com.baz.buzz.Dope.com.baz.buzz"),
-        Entity.dotted("com.baz.buzz.Dope.com.baz.buzz.Dope"),
         Entity.dotted("com.foo.bar.???"),
         Entity.dotted("com.foo.bar.Long"),
-        Entity.dotted("com.foo.bar.Nope"),
-        Entity.dotted("com.foo.bar.com"),
-        Entity.dotted("com.foo.bar.com.baz"),
-        Entity.dotted("com.foo.bar.com.baz.buzz"),
-        Entity.dotted("com.foo.bar.com.baz.buzz.Dope")
+        Entity.dotted("com.foo.bar.Nope")
       ),
       bzl_gen_build_commands = SortedSet.empty
     )
@@ -726,11 +639,6 @@ object MyObject {
       ),
       refs = SortedSet(
         Entity.dotted("com"),
-        Entity.dotted("com.foo.bar.com"),
-        Entity.dotted("com.foo.bar.com.monovore"),
-        Entity.dotted("com.foo.bar.com.monovore.decline"),
-        Entity.dotted("com.foo.bar.com.monovore.decline.Command"),
-        Entity.dotted("com.foo.bar.com.monovore.decline.Opts"),
         Entity.dotted("com.monovore"),
         Entity.dotted("com.monovore.decline"),
         Entity.dotted("com.monovore.decline.Command"),
@@ -760,7 +668,6 @@ object MyObject {
       ),
       refs = SortedSet(
         Entity.dotted("com"),
-        Entity.dotted("com.foo.bar.com"),
         Entity.dotted("CustTpe"),
         Entity.dotted("Unit"),
         Entity.dotted("com.animal"),
@@ -769,14 +676,9 @@ object MyObject {
         Entity.dotted("com.animal.foo.bar.baz"),
         Entity.dotted("com.foo.bar.CustTpe"),
         Entity.dotted("com.foo.bar.Unit"),
-        Entity.dotted("com.foo.bar.com.animal"),
-        Entity.dotted("com.foo.bar.com.animal.foo"),
-        Entity.dotted("com.foo.bar.com.animal.foo.bar"),
-        Entity.dotted("com.foo.bar.com.animal.foo.bar.baz"),
         Entity.dotted("com.foo.bar.sparkSession"),
         Entity.dotted("sparkSession"),
         Entity.dotted("com.animal.foo.bar.baz.CustTpe"),
-        Entity.dotted("com.foo.bar.com.animal.foo.bar.baz.CustTpe"),
         Entity.dotted("String"),
         Entity.dotted("com.foo.bar.String")
       ),


### PR DESCRIPTION
Previously, ever import that occurs after a wildcard import was tested to see if it was a relative import, such as:

    import com.acme._
    import ip.tools.Device // imports com.acme.ip.tools.Device

This causes problems when there are multiple wildcard imports folowed by a lot of imports, since you generate a combinatorial explosion of potential entities:

    import alpha._
    import beta._
    import gamma._

	import com.acme.ip.tools.Device
	// potential entities from this one import:
	// - com.acme.ip.tools.Device
	// - alpha.com.acme.ip.tools.Device
	// - beta.com.acme.ip.tools.Device
	// - gamma.com.acme.ip.tools.Device
	// - alpha.beta.com.acme.ip.tools.Device
	// - alpha.gamma.com.acme.ip.tools.Device
	// - beta.gamma.com.acme.ip.tools.Device
	// - alpha.beta.gamma.com.acme.ip.tools.Device

It is very rare to see "com" appear anywhere other than as the TLD, and it is even more rare to see an import that starts with com where it is not used as a TLD. So as a heuristic, this PR introduces a change where specially for imports starting with "com" we will not consider any previous wildcard imports.

**EDIT: Rather than hardcoding `com` we are now supporting configuration using the environment variable `BZL_GEN_SPECIAL_TLDS` to support zero-or-more of these.**

We still support explicit imports such as:

    import com.acme.net.com.Device